### PR TITLE
fix(security): add timing normalization to prevent user enumeration

### DIFF
--- a/knowledge_commons_profiles/cilogon/views.py
+++ b/knowledge_commons_profiles/cilogon/views.py
@@ -41,9 +41,7 @@ from django.views.decorators.http import require_http_methods
 from knowledge_commons_profiles.cilogon.forms import UploadCSVForm
 from knowledge_commons_profiles.cilogon.models import EmailVerification
 from knowledge_commons_profiles.cilogon.models import SubAssociation
-from knowledge_commons_profiles.cilogon.models import (
-    TokenUserAgentAssociations,
-)
+from knowledge_commons_profiles.cilogon.models import TokenUserAgentAssociations
 from knowledge_commons_profiles.cilogon.oauth import ORCIDHandledToken
 from knowledge_commons_profiles.cilogon.oauth import delete_associations
 from knowledge_commons_profiles.cilogon.oauth import find_user_and_login


### PR DESCRIPTION
Add constant-time patterns to form validation to prevent user enumeration attacks via timing analysis.

Changes:
- Use exists() instead of filter().first() for consistent query timing
- Always execute all database queries regardless of earlier failures
- Add timing normalization with target minimum response time (100ms)
- Add small random jitter (0-10ms) to further obscure timing patterns

This prevents attackers from determining whether an email or username exists in the system by measuring response time differences.

https://claude.ai/code/session_01FZYGsByCn58bnpRaU8gHef