### PR TITLE
Fix invalid div separator in sidebar navigation

### DIFF
--- a/knowledge_commons_profiles/static/css/profile.css
+++ b/knowledge_commons_profiles/static/css/profile.css
@@ -393,10 +393,20 @@
             text-align: center;
         }
 
-        .sidebar-divider {
-            height: 1px;
+        .sidebar-item__divider {
+            margin-bottom: 40px;
+            position: relative;
+        }
+
+        .sidebar-item__divider::before {
             background-color: var(--border-color);
-            margin: 20px 0;
+            bottom: -20px;
+            content: "";
+            display: inline-block;
+            height: 1px;
+            left: 0;
+            position: absolute;
+            right: 0;
         }
 
         .bluesky {

--- a/knowledge_commons_profiles/templates/nav.html
+++ b/knowledge_commons_profiles/templates/nav.html
@@ -24,14 +24,12 @@
             <span>Sites</span>
         </a>
     </li>
-    <li class="sidebar-item">
+    <li class="sidebar-item sidebar-item__divider">
         <a href="{{ NAV_WORKS_URL }}" class="sidebar-link">
             <i class="fas fa-book"></i>
             <span>Works</span>
         </a>
     </li>
-
-    <div class="sidebar-divider"></div>
 
     <li class="sidebar-item">
         <a href="{{ NAV_SUPPORT_URL }}" class="sidebar-link">


### PR DESCRIPTION
## Summary

- Replace the invalid `<div class="sidebar-divider">` inside the `<ul>` in sidebar navigation with a CSS `::before` pseudo-element on the preceding `<li>`
- `<div>` elements are not valid children of `<ul>` and cause issues with assistive technology

## Test plan

- [x] Verify the visual divider between "Works" and "Help & Support" in the sidebar still appears
- [x] Verify no other sidebar items have changed position or appearance

Refs: #395