### PR TITLE
Add nav landmark for site-wide navigation

### DIFF
--- a/knowledge_commons_profiles/templates/base.html
+++ b/knowledge_commons_profiles/templates/base.html
@@ -84,9 +84,9 @@
     <!-- Main Content with Sidebar -->
     <div class="main-with-sidebar">
         <!-- Sidebar -->
-        <aside class="sidebar" id="sidebar">
+        <nav class="sidebar" id="sidebar" aria-label="Site navigation">
             {% include "nav.html" %}
-        </aside>
+        </nav>
 
         <!-- Main Content Area -->
         <div class="content-wrapper">


### PR DESCRIPTION
## Summary

- Replace `<aside>` with `<nav>` element for the sidebar containing site-wide navigation
- Add `aria-label="Site navigation"` for landmark disambiguation
- All site-encompassing content should be contained within a landmark region per WCAG

## Test plan

- [x] Verify sidebar appearance and behavior is unchanged on desktop and mobile
- [x] Verify mobile nav toggle still opens/closes the sidebar

Refs: #384