### PR TITLE
Add accessible label to notification bell icon

### DIFF
--- a/knowledge_commons_profiles/templates/newprofile/partials/header_bar.html
+++ b/knowledge_commons_profiles/templates/newprofile/partials/header_bar.html
@@ -11,8 +11,8 @@
   <!-- notifications -->
   {% if notification_count %}
   <div class="notifications-container" hx-swap-oob="true" id="notifications-container">
-    <div class="notifications">
-      <i class="fas fa-bell"></i>
+    <div class="notifications" role="status" aria-label="Notifications ({{ notification_count }})">
+      <i class="fas fa-bell" aria-hidden="true"></i>
       <span class="notifications-count" id="notifications-count">{{ notification_count }}</span>
       {% if notification_count > 0 %}
         <div class="dropdown-menu">
@@ -31,8 +31,8 @@
   </div>
   {% else %}
     <div class="notifications-container" hx-swap-oob="true" id="notifications-container">
-      <div class="notifications">
-        <i class="fas fa-bell"></i>
+      <div class="notifications" aria-label="Notifications">
+        <i class="fas fa-bell" aria-hidden="true"></i>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
## Summary

- Add `aria-label="Notifications"` (with count when present) to the notification icon container
- Add `aria-hidden="true"` to the decorative bell `<i>` element
- Add `role="status"` to the notification area when there are notifications

## Test plan

- [x] Log in and verify the notification bell still appears and functions normally
- [x] Verify the notification dropdown still opens when clicked
- [x] Verify logged-out view is unaffected

Refs: #376