### PR TITLE
Add skip-to-content link and aria-hidden on nav icons

### DIFF
--- a/knowledge_commons_profiles/static/css/profile.css
+++ b/knowledge_commons_profiles/static/css/profile.css
@@ -1,3 +1,19 @@
+        .skip-to-content {
+            position: absolute;
+            left: -9999px;
+            top: 0;
+            z-index: 9999;
+            padding: 8px 16px;
+            background-color: var(--primary-color);
+            color: #fff;
+            text-decoration: none;
+            font-weight: 700;
+        }
+
+        .skip-to-content:focus {
+            left: 0;
+        }
+
 :root {
             --primary-color: #4a7c59;
             --secondary-color: #f8f9fa;

--- a/knowledge_commons_profiles/templates/base.html
+++ b/knowledge_commons_profiles/templates/base.html
@@ -43,6 +43,7 @@
 
 </head>
 <body>
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
     <!-- Header -->
     <header>
         <div class="container">
@@ -90,7 +91,7 @@
 
         <!-- Main Content Area -->
         <div class="content-wrapper">
-            <main class="main-content">
+            <main class="main-content" id="main-content">
                 {% block content %}
                 {% endblock content %}
             </main>

--- a/knowledge_commons_profiles/templates/nav.html
+++ b/knowledge_commons_profiles/templates/nav.html
@@ -2,31 +2,31 @@
 <ul class="sidebar-menu">
     <li class="sidebar-item">
         <a href="{{ NAV_NEWS_FEED_URL }}" class="sidebar-link">
-            <i class="fas fa-newspaper"></i>
+            <i class="fas fa-newspaper" aria-hidden="true"></i>
             <span>News Feed</span>
         </a>
     </li>
     <li class="sidebar-item">
         <a href="{% url "members" %}" class="sidebar-link">
-            <i class="fas fa-users"></i>
+            <i class="fas fa-users" aria-hidden="true"></i>
             <span>Members</span>
         </a>
     </li>
     <li class="sidebar-item">
         <a href="{{ NAV_GROUPS_URL }}" class="sidebar-link">
-            <i class="fas fa-user-friends"></i>
+            <i class="fas fa-user-friends" aria-hidden="true"></i>
             <span>Groups</span>
         </a>
     </li>
     <li class="sidebar-item">
         <a href="{{ NAV_SITES_URL }}" class="sidebar-link">
-            <i class="fas fa-globe"></i>
+            <i class="fas fa-globe" aria-hidden="true"></i>
             <span>Sites</span>
         </a>
     </li>
     <li class="sidebar-item">
         <a href="{{ NAV_WORKS_URL }}" class="sidebar-link">
-            <i class="fas fa-book"></i>
+            <i class="fas fa-book" aria-hidden="true"></i>
             <span>Works</span>
         </a>
     </li>
@@ -35,32 +35,32 @@
 
     <li class="sidebar-item">
         <a href="{{ NAV_SUPPORT_URL }}" class="sidebar-link">
-            <i class="fas fa-question-circle"></i>
+            <i class="fas fa-question-circle" aria-hidden="true"></i>
             <span>Help & Support</span>
         </a>
     </li>
     <li class="sidebar-item">
         <a href="{{ NAV_ORGANIZATIONS_URL }}" class="sidebar-link">
-            <i class="fas fa-building"></i>
+            <i class="fas fa-building" aria-hidden="true"></i>
             <span>KC Organizations</span>
         </a>
     </li>
     <li class="sidebar-item">
         <a href="{{ NAV_ABOUT_URL }}" class="sidebar-link">
-            <i class="fas fa-info-circle"></i>
+            <i class="fas fa-info-circle" aria-hidden="true"></i>
             <span>About the Commons</span>
         </a>
     </li>
     <li class="sidebar-item">
         <a href="{{ NAV_BLOG_URL }}" class="sidebar-link">
-            <i class="fas fa-pencil-alt"></i>
+            <i class="fas fa-pencil-alt" aria-hidden="true"></i>
             <span>Team Blog</span>
         </a>
     </li>
     {% if request.user.is_authenticated %}
     <li class="sidebar-item" id="logout">
         <a href="{% url 'logout' %}" class="sidebar-link">
-            <i class="fas fa-sign-out"></i>
+            <i class="fas fa-sign-out" aria-hidden="true"></i>
             <span>Logout</span>
         </a>
     </li>


### PR DESCRIPTION
## Summary

- Add a visually-hidden "Skip to main content" link as the first focusable element on every page — visible only on keyboard focus
- Add `id="main-content"` to the `<main>` element as the skip link target
- Add `aria-hidden="true"` to all decorative Font Awesome icons in sidebar navigation

## Test plan

- [x] Tab into the page — verify "Skip to main content" link appears on first Tab press
- [x] Press Enter on the skip link — verify focus moves to main content area
- [x] Verify skip link is not visible when not focused
- [x] Verify sidebar navigation layout is unchanged


Refs: #415, #419