### PR TITLE
Add labels to social links and photo upload modals

### DIFF
--- a/knowledge_commons_profiles/templates/newprofile/partials/change_cover_photo.html
+++ b/knowledge_commons_profiles/templates/newprofile/partials/change_cover_photo.html
@@ -1,14 +1,15 @@
 <!-- Modal -->
-<div class="modal fade" id="coverModal" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="coverModal" tabindex="-1" aria-hidden="true" aria-labelledby="coverModalLabel">
   <div class="modal-dialog modal-lg">
     <form id="coverForm" class="modal-content" enctype="multipart/form-data">
       {% csrf_token %}
       <div class="modal-header">
-        <h5 class="modal-title">Upload & Crop Cover Image</h5>
+        <h5 class="modal-title" id="coverModalLabel">Upload & Crop Cover Image</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
 
       <div class="modal-body">
+        <label for="coverInput" class="form-label">Choose an image</label>
         <input type="file" id="coverInput" name="image" accept="image/*" class="form-control mb-3" required/>
 
         <!-- Cropper container where v2 injects its template -->

--- a/knowledge_commons_profiles/templates/newprofile/partials/change_profile_photo.html
+++ b/knowledge_commons_profiles/templates/newprofile/partials/change_profile_photo.html
@@ -1,15 +1,16 @@
 <script src="https://unpkg.com/cropperjs@2/dist/cropper.js"></script>
 <!-- Modal -->
-<div class="modal fade" id="avatarModal" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="avatarModal" tabindex="-1" aria-hidden="true" aria-labelledby="avatarModalLabel">
   <div class="modal-dialog modal-lg">
     <form id="avatarForm" class="modal-content" enctype="multipart/form-data">
       {% csrf_token %}
       <div class="modal-header">
-        <h5 class="modal-title">Upload & Crop Avatar</h5>
+        <h5 class="modal-title" id="avatarModalLabel">Upload & Crop Avatar</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
 
       <div class="modal-body">
+        <label for="avatarInput" class="form-label">Choose an image</label>
         <input type="file" id="avatarInput" name="image" accept="image/*" class="form-control mb-3" required/>
 
         <!-- Cropper container where v2 injects its template -->

--- a/knowledge_commons_profiles/templates/newprofile/profile.html
+++ b/knowledge_commons_profiles/templates/newprofile/profile.html
@@ -34,23 +34,23 @@
           </p>
 
           <div class="profile-social">
-            <a href="#" class="social-link" id="mastodon">
-              <i class="fab fa-mastodon"></i>
+            <a href="#" class="social-link" id="mastodon" aria-label="Mastodon">
+              <i class="fab fa-mastodon" aria-hidden="true"></i>
             </a>
-            <a href="#" class="social-link" id="twitter">
-              <i class="fab fa-twitter"></i>
+            <a href="#" class="social-link" id="twitter" aria-label="Twitter">
+              <i class="fab fa-twitter" aria-hidden="true"></i>
             </a>
-            <a href="#" class="social-link" id="bluesky">
+            <a href="#" class="social-link" id="bluesky" aria-label="Bluesky">
               <img class="bluesky" src="{% static "img/bluesky.png" %}"
-                   alt="bluesky"/>
+                   alt="Bluesky" aria-hidden="true"/>
             </a>
             <a href="{% url "profile" user=username %}" class="social-link"
                id="kc">
-              <i class="fas fa-at"></i>
+              <i class="fas fa-at" aria-hidden="true"></i>
               <span>{{ username }}{% if user and user.is_staff %} (Knowledge Commons Staff){% endif %}</span>
             </a>
-            <a href="#" class="social-link" id="orcid">
-              <img src="{% static "img/iD-icon.png" %}" alt="ORCID"/>
+            <a href="#" class="social-link" id="orcid" aria-label="ORCID">
+              <img src="{% static "img/iD-icon.png" %}" alt="ORCID" aria-hidden="true"/>
             </a>
 
             <a href="#" class="social-link" id="arlisna">


### PR DESCRIPTION
## Summary

- Add `aria-label` to icon-only social media links (Mastodon, Twitter, Bluesky, ORCID) on the profile page
- Add `aria-hidden="true"` to decorative Font Awesome icons and images within social links
- Add `aria-labelledby` to avatar and cover photo upload modals, pointing to their `<h5>` titles
- Add visible `<label>` elements for the file input fields in both modals

## Test plan

- [x] Verify social links on a profile page appear and function as before
- [x] Open the avatar upload modal — verify "Choose an image" label appears above the file input
- [x] Open the cover photo upload modal — verify same label appears
- [x] Verify no visual layout changes on profile pages

Refs: #417, #420