### PR TITLE
ci: target dependabot PRs at dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   # Update GitHub actions in workflows
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'dev'
     # Every weekday
     schedule:
       interval: 'daily'
@@ -17,6 +18,7 @@ updates:
       - 'compose/local/django/'
       - 'compose/local/docs/'
       - 'compose/production/django/'
+    target-branch: 'dev'
     # Every weekday
     schedule:
       interval: 'daily'
@@ -35,6 +37,7 @@ updates:
       - 'compose/production/aws/'
       - 'compose/production/postgres/'
       - 'compose/production/traefik/'
+    target-branch: 'dev'
     # Every weekday
     schedule:
       interval: 'daily'
@@ -42,6 +45,7 @@ updates:
   # Enable version updates for Python/uv
   - package-ecosystem: 'uv'
     directory: '/'
+    target-branch: 'dev'
     # Every weekday
     schedule:
       interval: 'daily'


### PR DESCRIPTION
## Summary
- Adds `target-branch: dev` to all four Dependabot ecosystem entries (github-actions, docker x2, uv)
- Dependabot will now open version-update and security PRs against `dev` instead of `main`

## Test plan
- [x] Verify Dependabot picks up the config from main after merge
- [x] Confirm next Dependabot PR targets `dev`