### PR TITLE
fix(tests): mock external HTTP calls in logout and utils tests

### DIFF
--- a/knowledge_commons_profiles/cilogon/tests/test_views_extended.py
+++ b/knowledge_commons_profiles/cilogon/tests/test_views_extended.py
@@ -442,14 +442,27 @@ class LogoutTests(CILogonTestBase):
         request.session.create()
         request.user = self.user
 
-        with patch(
-            "knowledge_commons_profiles.cilogon.views.logout"
-        ) as logout_mock:
+        with (
+            patch(
+                "knowledge_commons_profiles.cilogon.views.logout"
+            ) as logout_mock,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.oauth.create_client"
+            ) as client_mock,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.logout_all_endpoints_sync"
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_client.server_metadata = {
+                "revocation_endpoint": "https://test.com/revoke"
+            }
+            client_mock.return_value = mock_client
+
             app_logout(request)
 
             # Should call Django logout
             logout_mock.assert_called_once_with(request)
-            # Should redirect
 
     def test_app_logout_anonymous_user(self):
         """Test logout for anonymous user"""
@@ -458,9 +471,23 @@ class LogoutTests(CILogonTestBase):
         request.session.create()
         request.user = AnonymousUser()
 
-        with patch(
-            "knowledge_commons_profiles.cilogon.views.logout"
-        ) as logout_mock:
+        with (
+            patch(
+                "knowledge_commons_profiles.cilogon.views.logout"
+            ) as logout_mock,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.oauth.create_client"
+            ) as client_mock,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.logout_all_endpoints_sync"
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_client.server_metadata = {
+                "revocation_endpoint": "https://test.com/revoke"
+            }
+            client_mock.return_value = mock_client
+
             app_logout(request)
 
             # Should still call logout even for anonymous users
@@ -489,6 +516,9 @@ class LogoutTests(CILogonTestBase):
             patch(
                 "knowledge_commons_profiles.cilogon.views.oauth.create_client"
             ) as client_mock,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.logout_all_endpoints_sync"
+            ),
         ):
             # Mock the OAuth client
             mock_client = MagicMock()
@@ -538,6 +568,9 @@ class LogoutTests(CILogonTestBase):
             patch(
                 "knowledge_commons_profiles.cilogon.views.delete_associations",
                 side_effect=DatabaseError("DB Error"),
+            ),
+            patch(
+                "knowledge_commons_profiles.cilogon.views.logout_all_endpoints_sync"
             ),
         ):
             # Mock the OAuth client

--- a/knowledge_commons_profiles/rest_api/tests/test_utils.py
+++ b/knowledge_commons_profiles/rest_api/tests/test_utils.py
@@ -355,13 +355,19 @@ class TestLogoutAllEndpointsSync(TestCase):
     @override_settings(STATIC_API_BEARER="test-token")
     def test_missing_logout_endpoints_setting(self):
         """Test function handles missing LOGOUT_ENDPOINTS setting."""
-        with patch("django.conf.settings") as mock_settings:
-            # Remove LOGOUT_ENDPOINTS attribute
-            mock_settings.STATIC_API_BEARER = "test-token"
-            del mock_settings.LOGOUT_ENDPOINTS
+        from django.conf import settings
 
+        # Temporarily remove LOGOUT_ENDPOINTS if it exists
+        had_attr = hasattr(settings, "LOGOUT_ENDPOINTS")
+        if had_attr:
+            original = settings.LOGOUT_ENDPOINTS
+            delattr(settings, "LOGOUT_ENDPOINTS")
+        try:
             result = logout_all_endpoints_sync()
             self.assertEqual(result, [])
+        finally:
+            if had_attr:
+                settings.LOGOUT_ENDPOINTS = original
 
     @override_settings(
         LOGOUT_ENDPOINTS=["https://api1.com/logout"],


### PR DESCRIPTION
## Summary
- Mock `oauth.create_client` and `logout_all_endpoints_sync` in all `LogoutTests` to prevent real calls to cilogon.org and hcommons-staging.org
- Fix `test_missing_logout_endpoints_setting` to properly remove the `LOGOUT_ENDPOINTS` setting, preventing real HTTP calls

## Test plan
- [x] All 708 tests pass locally with no external network calls
- [x] CI linter and test jobs pass