### PR TITLE
chore(deps): bump requests from 2.32.5 to 2.33.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,7 @@ dependencies = [
     "altair==6.0.0",
     "django-basicauth==0.5.3",
     "Authlib==1.6.9",
-    "requests==2.32.5",
+    "requests==2.33.0",
     "nameparser==1.1.3",
     "tldextract==5.3.1",
     "drf-yasg==1.21.15",

--- a/uv.lock
+++ b/uv.lock
@@ -2036,7 +2036,7 @@ requires-dist = [
     { name = "python-json-logger", specifier = "==4.0.0" },
     { name = "python-slugify", specifier = "==8.0.4" },
     { name = "redis", specifier = "==7.4.0" },
-    { name = "requests", specifier = "==2.32.5" },
+    { name = "requests", specifier = "==2.33.0" },
     { name = "rich", specifier = "==14.3.3" },
     { name = "smart-open", specifier = "==7.5.0" },
     { name = "sparkpost", specifier = "==1.3.10" },
@@ -2946,7 +2946,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2954,9 +2954,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps requests from 2.32.5 to 2.33.0
- Replaces Dependabot PR #431 which targeted main (black bump from that PR is already on dev)

## Test plan
- [x] CI linter and test jobs pass