### PR TITLE
fix(a11y): add title attribute to search submit button

### DIFF
--- a/knowledge_commons_profiles/templates/base.html
+++ b/knowledge_commons_profiles/templates/base.html
@@ -58,7 +58,7 @@
                       <form id="search-form" action="{% url 'search' %}" role="search">
                         <label for="q" class="visually-hidden">Search</label>
                         <input type="text" id="q" name="q" placeholder="Search" />
-                        <button type="submit" aria-label="Submit search">
+                        <button type="submit" aria-label="Submit search" title="Submit search">
                             <i class="fas fa-search" aria-hidden="true"></i>
                         </button>
                       </form>


### PR DESCRIPTION
## Summary
- Adds `title="Submit search"` to the search submit button alongside the existing `aria-label`
- The `title` provides a visible tooltip on hover for sighted users, complementing the `aria-label` for screen readers
- Follows up on PR #412 which added `aria-label` but not `title`, as recommended in #394

## Test plan
- [x] Hover over the search icon and verify "Submit search" tooltip appears
- [x] Screen reader announces "Submit search" for the button

Refs: #394