### PR TITLE
fix(a11y): show hamburger menu on mobile, replace KC logo

### DIFF
--- a/knowledge_commons_profiles/static/css/profile.css
+++ b/knowledge_commons_profiles/static/css/profile.css
@@ -186,7 +186,7 @@
             cursor: pointer;
             color: var(--text-color);
             margin-left: 10px;
-            display: none;
+            display: inline-block;
         }
 
         .search-container {
@@ -779,10 +779,6 @@
             .col-md-6 { flex: 0 0 50%; max-width: 50%; }
             .col-md-8 { flex: 0 0 66.666667%; max-width: 66.666667%; }
             .col-md-4 { flex: 0 0 33.333333%; max-width: 33.333333%; }
-
-            .mobile-nav-toggle {
-                display: inline-block;
-            }
         }
 
         @media (min-width: 992px) {
@@ -867,6 +863,15 @@
             .logo-container {
                 justify-content: space-between;
                 width: 100%;
+            }
+
+            .kc-hero-logo-mark {
+                display: none;
+            }
+
+            .mobile-nav-toggle {
+                margin-left: 0;
+                font-size: 28px;
             }
 
             .header-right {
@@ -1799,6 +1804,7 @@ div {
     }
 
     .kc-hero-logo-mark {
+      min-width: 70px;
       width: 70px;
       height: 70px;
       border-radius: 18px;


### PR DESCRIPTION
## Summary
- Hamburger menu is now visible on all sub-desktop screen sizes (<992px), not just 768-992px
- On mobile (<768px), the KC logo is hidden and the hamburger takes its place
- KC logo gets `min-width: 70px` to prevent squashing at intermediate responsive sizes

## Changes
- Default `.mobile-nav-toggle` changed from `display: none` to `display: inline-block`
- Removed redundant `min-width: 768px` media query for hamburger visibility
- Added `max-width: 767.98px` rules to hide `.kc-hero-logo-mark` and style the hamburger as replacement

## Test plan
- [x] On mobile (<768px): hamburger visible, KC logo hidden, hamburger opens sidebar
- [x] On tablet (768-991px): both KC logo and hamburger visible, logo not squashed
- [x] On desktop (992px+): sidebar always visible, hamburger hidden