### PR TITLE
feat(monitor): add S3-based state persistence and auto-deactivation

### DIFF
--- a/aws/monitor-task-definition.json
+++ b/aws/monitor-task-definition.json
@@ -31,6 +31,10 @@
         {
           "name": "CHECK_INTERVAL",
           "value": "60"
+        },
+        {
+          "name": "MONITOR_S3_BUCKET",
+          "value": "YOUR_BUCKET_NAME"
         }
       ],
       "secrets": [

--- a/aws/setup-iam.sh
+++ b/aws/setup-iam.sh
@@ -116,6 +116,29 @@ aws iam put-role-policy \
     --policy-name ALBModifyAccess \
     --policy-document "${ALB_POLICY}"
 
+# S3 state persistence policy
+echo "Adding S3 state persistence permissions..."
+S3_STATE_BUCKET="${MONITOR_S3_BUCKET:-hcommons-profiles-storage}"
+S3_STATE_POLICY='{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::'${S3_STATE_BUCKET}'/monitor/*"
+    }
+  ]
+}'
+
+aws iam put-role-policy \
+    --role-name ${TASK_ROLE_NAME} \
+    --policy-name S3StateAccess \
+    --policy-document "${S3_STATE_POLICY}"
+
 echo ""
 echo "=== IAM Setup Complete ==="
 echo ""

--- a/knowledge_commons_profiles/cron/monitor_website.py
+++ b/knowledge_commons_profiles/cron/monitor_website.py
@@ -13,6 +13,10 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from dataclasses import field
+from datetime import UTC
+from datetime import datetime
+from enum import Enum
 from typing import Any
 
 import environ
@@ -41,6 +45,14 @@ LISTENER_RULE_ARN = (
 CHECK_INTERVAL = 60  # seconds
 REQUEST_TIMEOUT = 10  # seconds
 SITE_DOWN_THRESHOLD = 2  # Number of consecutive failures before taking action
+
+# Timing constants
+ACTIVATION_DURATION = 3600  # seconds (1 hour) before auto-deactivation
+GRACE_PERIOD_DURATION = 300  # seconds (5 minutes) after deactivation
+
+# S3 configuration
+S3_STATE_BUCKET = env("MONITOR_S3_BUCKET", default="")
+S3_STATE_KEY = "monitor/alb-rule-state.json"
 
 # HTTP status code ranges
 HTTP_STATUS_OK_MIN = 200
@@ -163,12 +175,23 @@ class SparkPostEmailClient:
             }
 
 
+class MonitorPhase(Enum):
+    """Phases of the monitor state machine."""
+
+    MONITORING = "monitoring"
+    ACTIVATED = "activated"
+    GRACE_PERIOD = "grace_period"
+
+
 @dataclass
 class MonitorState:
     """State tracking for the monitor."""
 
     consecutive_failures: int = 0
-    rule_modified: bool = False
+    phase: MonitorPhase = MonitorPhase.MONITORING
+    activated_at: datetime | None = None
+    original_http_methods: list[str] | None = field(default=None)
+    grace_period_start: datetime | None = None
     test_mode: bool = False
 
 
@@ -369,16 +392,18 @@ def send_email():
         html_content=(
             "<h1>Attack Blocked</h1>"
             "<p>The system has automatically engaged the AWS ALB "
-            "listener rule that blocks the members routes. "
-            "When the site has recovered, you should manually "
-            "remove this.</p>"
+            "listener rule that blocks the members routes.</p>"
+            "<p>This protection will be <strong>automatically removed "
+            "after 1 hour</strong>. If the site is still down at that "
+            "point, it will re-activate if downtime continues.</p>"
         ),
         text_content=(
             "Attack Blocked. "
             "The system has automatically engaged the AWS ALB "
             "listener rule that blocks the members routes. "
-            "When the site has recovered, you should manually "
-            "remove this."
+            "This protection will be automatically removed after 1 hour. "
+            "If the site is still down at that point, it will re-activate "
+            "if downtime continues."
         ),
         recipients=RECIPIENTS,
         tags=["system", "ddos"],
@@ -410,16 +435,264 @@ def build_cmd(new_conditions: list[Any], rule_arn: str) -> list[str]:
     ]
 
 
+def _now() -> datetime:
+    """Return current UTC time. Extracted for testability."""
+    return datetime.now(UTC)
+
+
+def save_state_to_s3(
+    bucket: str,
+    key: str,
+    activated_at: datetime,
+    original_http_methods: list[str],
+    rule_arn: str,
+) -> bool:
+    """Save activation state to S3 for persistence across restarts."""
+    if not bucket:
+        logger.warning("No S3 bucket configured, skipping state save")
+        return False
+
+    state_data = {
+        "activated_at": activated_at.isoformat(),
+        "original_http_methods": original_http_methods,
+        "rule_arn": rule_arn,
+        "version": 1,
+    }
+
+    cmd = [
+        "aws", "s3", "cp", "-",
+        f"s3://{bucket}/{key}",
+        "--content-type", "application/json",
+    ]
+
+    try:
+        subprocess.run(  # noqa: S603
+            cmd,
+            input=json.dumps(state_data),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        logger.exception("Failed to save state to S3: %s", e.stderr)
+        return False
+
+    logger.info("Saved activation state to S3")
+    return True
+
+
+def load_state_from_s3(bucket: str, key: str) -> dict | None:
+    """Load activation state from S3. Returns None if no state exists."""
+    if not bucket:
+        return None
+
+    cmd = ["aws", "s3", "cp", f"s3://{bucket}/{key}", "-"]
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd, capture_output=True, text=True, check=False
+        )
+    except subprocess.CalledProcessError:
+        logger.exception("Failed to load state from S3")
+        return None
+
+    if result.returncode != 0:
+        logger.info("No existing state found in S3")
+        return None
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.exception("Failed to parse S3 state JSON")
+        return None
+
+
+def delete_state_from_s3(bucket: str, key: str) -> bool:
+    """Delete activation state from S3 after deactivation."""
+    if not bucket:
+        return False
+
+    cmd = ["aws", "s3", "rm", f"s3://{bucket}/{key}"]
+
+    try:
+        subprocess.run(  # noqa: S603
+            cmd, capture_output=True, text=True, check=True
+        )
+    except subprocess.CalledProcessError as e:
+        logger.exception("Failed to delete state from S3: %s", e.stderr)
+        return False
+
+    logger.info("Deleted activation state from S3")
+    return True
+
+
+def restore_http_method_restriction(
+    rule_arn: str, http_methods: list[str]
+) -> bool:
+    """Restore the HTTP request method restriction on the ALB listener rule."""
+    rule = get_listener_rule_details(rule_arn)
+    if not rule:
+        logger.error("Could not retrieve rule details for restoration")
+        return False
+
+    current_conditions = rule.get("Conditions", [])
+
+    # Check if HTTP method condition already exists (idempotency)
+    for cond in current_conditions:
+        if cond.get("Field") == "http-request-method":
+            logger.info("HTTP method restriction already present")
+            return True
+
+    # Add the HTTP method condition back
+    http_method_condition = {
+        "Field": "http-request-method",
+        "HttpRequestMethodConfig": {"Values": http_methods},
+    }
+    new_conditions = [
+        normalize_condition_format(cond) for cond in current_conditions
+    ] + [http_method_condition]
+
+    cmd = build_cmd(new_conditions, rule_arn)
+
+    logger.info("Restoring HTTP request method restriction on rule")
+    try:
+        subprocess.run(  # noqa: S603
+            cmd, capture_output=True, text=True, check=True
+        )
+    except subprocess.CalledProcessError as e:
+        logger.exception("AWS CLI error restoring rule: %s", e.stderr)
+        return False
+
+    logger.info("Successfully restored HTTP request method restriction")
+    return True
+
+
+def send_deactivation_email():
+    """Send email notifying that DDOS protection has been deactivated."""
+    client = SparkPostEmailClient()
+
+    response = client.send_email(
+        from_email="system@hcommons.org",
+        from_name="Knowledge Commons System",
+        subject="DDOS Protection has been automatically deactivated",
+        html_content=(
+            "<h1>Protection Deactivated</h1>"
+            "<p>The AWS ALB listener rule that blocks the members routes "
+            "has been automatically restored after 1 hour. "
+            "Normal monitoring has resumed after a brief grace period.</p>"
+            "<p>If the site is still experiencing issues, the protection "
+            "will re-activate automatically if downtime is detected.</p>"
+        ),
+        text_content=(
+            "Protection Deactivated. "
+            "The AWS ALB listener rule that blocks the members routes "
+            "has been automatically restored after 1 hour. "
+            "Normal monitoring has resumed after a brief grace period. "
+            "If the site is still experiencing issues, the protection "
+            "will re-activate automatically if downtime is detected."
+        ),
+        recipients=RECIPIENTS,
+        tags=["system", "ddos"],
+    )
+
+    logger.info("Deactivation email response: %s", response)
+    return response
+
+
+def check_activation_timeout():
+    """Check if the activation has exceeded the timeout and deactivate."""
+    if state.phase != MonitorPhase.ACTIVATED or state.activated_at is None:
+        return
+
+    elapsed = (_now() - state.activated_at).total_seconds()
+    if elapsed < ACTIVATION_DURATION:
+        return
+
+    logger.info(
+        "Activation duration exceeded (%s seconds). Restoring rule...",
+        elapsed,
+    )
+
+    if restore_http_method_restriction(
+        LISTENER_RULE_ARN, state.original_http_methods
+    ):
+        logger.info("HTTP method restriction restored successfully")
+        delete_state_from_s3(S3_STATE_BUCKET, S3_STATE_KEY)
+        send_deactivation_email()
+        state.phase = MonitorPhase.GRACE_PERIOD
+        state.grace_period_start = _now()
+        state.activated_at = None
+        state.original_http_methods = None
+        state.consecutive_failures = 0
+    else:
+        logger.error("Failed to restore HTTP method restriction")
+
+
+def check_grace_period():
+    """Check if the grace period has elapsed and return to monitoring."""
+    if (
+        state.phase != MonitorPhase.GRACE_PERIOD
+        or state.grace_period_start is None
+    ):
+        return
+
+    elapsed = (_now() - state.grace_period_start).total_seconds()
+    if elapsed >= GRACE_PERIOD_DURATION:
+        logger.info("Grace period complete. Resuming normal monitoring.")
+        state.phase = MonitorPhase.MONITORING
+        state.grace_period_start = None
+        state.consecutive_failures = 0
+
+
+def initialize_state_from_s3():
+    """Check S3 for existing activation state (handles ECS restarts)."""
+    if not S3_STATE_BUCKET:
+        logger.warning("No S3 bucket configured, state persistence disabled")
+        return
+
+    saved = load_state_from_s3(S3_STATE_BUCKET, S3_STATE_KEY)
+    if saved is None:
+        logger.info("No existing activation state found in S3")
+        return
+
+    if saved.get("rule_arn") != LISTENER_RULE_ARN:
+        logger.warning("S3 state rule_arn mismatch, ignoring")
+        return
+
+    activated_at = datetime.fromisoformat(saved["activated_at"])
+    original_methods = saved.get("original_http_methods", ["GET", "POST"])
+    elapsed = (_now() - activated_at).total_seconds()
+
+    if elapsed >= ACTIVATION_DURATION:
+        logger.info(
+            "Found expired activation state (%s seconds ago). "
+            "Restoring rule...",
+            elapsed,
+        )
+        if restore_http_method_restriction(LISTENER_RULE_ARN, original_methods):
+            delete_state_from_s3(S3_STATE_BUCKET, S3_STATE_KEY)
+            send_deactivation_email()
+            state.phase = MonitorPhase.GRACE_PERIOD
+            state.grace_period_start = _now()
+        else:
+            logger.error("Failed to restore rule from expired S3 state")
+            state.phase = MonitorPhase.ACTIVATED
+            state.activated_at = activated_at
+            state.original_http_methods = original_methods
+    else:
+        logger.info(
+            "Found active activation state (%s seconds ago). "
+            "Resuming activated state.",
+            elapsed,
+        )
+        state.phase = MonitorPhase.ACTIVATED
+        state.activated_at = activated_at
+        state.original_http_methods = original_methods
+
+
 def handle_site_up():
     """Handle the case when the website is up."""
     state.consecutive_failures = 0
-
-    if state.rule_modified:
-        logger.info("Website is back up. Rule modification will remain.")
-        logger.info(
-            "Note: You may want to manually restore the HTTP "
-            "method restriction when ready."
-        )
 
 
 def handle_site_down():
@@ -432,7 +705,7 @@ def handle_site_down():
 
     if (
         state.consecutive_failures >= SITE_DOWN_THRESHOLD
-        and not state.rule_modified
+        and state.phase == MonitorPhase.MONITORING
     ):
         logger.warning(
             "Website down for %s checks. Removing HTTP method restriction...",
@@ -441,15 +714,32 @@ def handle_site_down():
 
         # Get and store original HTTP methods before modifying
         rule = get_listener_rule_details(LISTENER_RULE_ARN)
+        original_methods = ["GET", "POST"]
         if rule:
             for condition in rule.get("Conditions", []):
                 if condition.get("Field") == "http-request-method":
-                    _ = condition.get("Values", ["GET", "POST"])
+                    config = condition.get("HttpRequestMethodConfig", {})
+                    original_methods = config.get(
+                        "Values",
+                        condition.get("Values", ["GET", "POST"]),
+                    )
                     break
 
         if remove_http_method_restriction(LISTENER_RULE_ARN):
-            state.rule_modified = True
+            now = _now()
+            state.phase = MonitorPhase.ACTIVATED
+            state.activated_at = now
+            state.original_http_methods = original_methods
             logger.info("HTTP method restriction removed successfully")
+
+            save_state_to_s3(
+                S3_STATE_BUCKET,
+                S3_STATE_KEY,
+                now,
+                original_methods,
+                LISTENER_RULE_ARN,
+            )
+
             send_email()
         else:
             logger.error("Failed to remove HTTP method restriction")
@@ -467,16 +757,21 @@ def monitor_loop():
     if state.test_mode:
         logger.warning("TEST MODE ENABLED - Site will be simulated as DOWN")
 
+    initialize_state_from_s3()
+
     try:
         while True:
-            is_up = check_website_status(WEBSITE_URL)
+            if state.phase == MonitorPhase.MONITORING:
+                is_up = check_website_status(WEBSITE_URL)
+                if is_up:
+                    handle_site_up()
+                else:
+                    handle_site_down()
+            elif state.phase == MonitorPhase.ACTIVATED:
+                check_activation_timeout()
+            elif state.phase == MonitorPhase.GRACE_PERIOD:
+                check_grace_period()
 
-            if is_up:
-                handle_site_up()
-            else:
-                handle_site_down()
-
-            # Wait before next check
             logger.info("Next check in %s seconds...", CHECK_INTERVAL)
             time.sleep(CHECK_INTERVAL)
 

--- a/knowledge_commons_profiles/cron/tests/test_monitor_website.py
+++ b/knowledge_commons_profiles/cron/tests/test_monitor_website.py
@@ -4,6 +4,8 @@ Test suite for website uptime monitor module.
 
 import json
 import subprocess
+from datetime import UTC
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -12,19 +14,37 @@ import requests
 from knowledge_commons_profiles.cron import monitor_website
 from knowledge_commons_profiles.cron.monitor_website import HTTP_STATUS_OK_MAX
 from knowledge_commons_profiles.cron.monitor_website import HTTP_STATUS_OK_MIN
+from knowledge_commons_profiles.cron.monitor_website import MonitorPhase
 from knowledge_commons_profiles.cron.monitor_website import MonitorState
+from knowledge_commons_profiles.cron.monitor_website import _now
 from knowledge_commons_profiles.cron.monitor_website import build_cmd
+from knowledge_commons_profiles.cron.monitor_website import (
+    check_activation_timeout,
+)
+from knowledge_commons_profiles.cron.monitor_website import check_grace_period
 from knowledge_commons_profiles.cron.monitor_website import check_website_status
+from knowledge_commons_profiles.cron.monitor_website import delete_state_from_s3
 from knowledge_commons_profiles.cron.monitor_website import (
     get_listener_rule_details,
 )
 from knowledge_commons_profiles.cron.monitor_website import handle_site_down
 from knowledge_commons_profiles.cron.monitor_website import handle_site_up
 from knowledge_commons_profiles.cron.monitor_website import (
+    initialize_state_from_s3,
+)
+from knowledge_commons_profiles.cron.monitor_website import load_state_from_s3
+from knowledge_commons_profiles.cron.monitor_website import (
     normalize_condition_format,
 )
 from knowledge_commons_profiles.cron.monitor_website import (
     remove_http_method_restriction,
+)
+from knowledge_commons_profiles.cron.monitor_website import (
+    restore_http_method_restriction,
+)
+from knowledge_commons_profiles.cron.monitor_website import save_state_to_s3
+from knowledge_commons_profiles.cron.monitor_website import (
+    send_deactivation_email,
 )
 from knowledge_commons_profiles.cron.monitor_website import send_email
 from knowledge_commons_profiles.cron.monitor_website import state
@@ -36,6 +56,8 @@ EXPECTED_STATUS_OK_MAX = 400
 TEST_RULE_ARN = (
     "arn:aws:elasticloadbalancing:us-east-1:123456789:listener-rule/test"
 )
+TEST_S3_BUCKET = "test-bucket"
+TEST_S3_KEY = "monitor/alb-rule-state.json"
 
 
 class TestMonitorState:
@@ -45,18 +67,27 @@ class TestMonitorState:
         """Test that MonitorState has correct default values."""
         monitor_state = MonitorState()
         assert monitor_state.consecutive_failures == 0
-        assert monitor_state.rule_modified is False
+        assert monitor_state.phase == MonitorPhase.MONITORING
+        assert monitor_state.activated_at is None
+        assert monitor_state.original_http_methods is None
+        assert monitor_state.grace_period_start is None
         assert monitor_state.test_mode is False
 
     def test_custom_values(self):
         """Test that MonitorState accepts custom values."""
+        now = datetime(2026, 3, 30, 12, 0, 0, tzinfo=UTC)
         monitor_state = MonitorState(
             consecutive_failures=TEST_FAILURE_COUNT,
-            rule_modified=True,
+            phase=MonitorPhase.ACTIVATED,
+            activated_at=now,
+            original_http_methods=["GET", "POST"],
+            grace_period_start=None,
             test_mode=True,
         )
         assert monitor_state.consecutive_failures == TEST_FAILURE_COUNT
-        assert monitor_state.rule_modified is True
+        assert monitor_state.phase == MonitorPhase.ACTIVATED
+        assert monitor_state.activated_at == now
+        assert monitor_state.original_http_methods == ["GET", "POST"]
         assert monitor_state.test_mode is True
 
 
@@ -67,12 +98,18 @@ class TestCheckWebsiteStatus:
     def reset_state(self):
         """Reset the global state before each test."""
         state.consecutive_failures = 0
-        state.rule_modified = False
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
         state.test_mode = False
         yield
         # Reset after test too
         state.consecutive_failures = 0
-        state.rule_modified = False
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
         state.test_mode = False
 
     def test_returns_true_for_successful_response(self):
@@ -501,11 +538,17 @@ class TestHandleSiteUp:
     def reset_state(self):
         """Reset the global state before each test."""
         state.consecutive_failures = 0
-        state.rule_modified = False
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
         state.test_mode = False
         yield
         state.consecutive_failures = 0
-        state.rule_modified = False
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
         state.test_mode = False
 
     def test_resets_consecutive_failures(self):
@@ -516,14 +559,11 @@ class TestHandleSiteUp:
 
         assert state.consecutive_failures == 0
 
-    def test_does_not_reset_rule_modified_flag(self):
-        """Test that rule_modified flag persists after site comes back up."""
-        state.rule_modified = True
-
+    def test_does_not_change_phase(self):
+        """Test that phase is not changed by handle_site_up."""
         handle_site_up()
 
-        # Rule modification should persist - requires manual restoration
-        assert state.rule_modified is True
+        assert state.phase == MonitorPhase.MONITORING
 
 
 class TestHandleSiteDown:
@@ -533,11 +573,17 @@ class TestHandleSiteDown:
     def reset_state(self):
         """Reset the global state before each test."""
         state.consecutive_failures = 0
-        state.rule_modified = False
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
         state.test_mode = False
         yield
         state.consecutive_failures = 0
-        state.rule_modified = False
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
         state.test_mode = False
 
     def test_increments_consecutive_failures(self):
@@ -563,6 +609,7 @@ class TestHandleSiteDown:
     def test_modifies_rule_at_threshold(self):
         """Test that rule is modified when threshold is reached."""
         state.consecutive_failures = monitor_website.SITE_DOWN_THRESHOLD - 1
+        now = datetime(2026, 3, 30, 12, 0, 0, tzinfo=UTC)
 
         with (
             mock.patch(
@@ -576,20 +623,83 @@ class TestHandleSiteDown:
             mock.patch(
                 "knowledge_commons_profiles.cron.monitor_website.send_email"
             ) as mock_email,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "save_state_to_s3"
+            ) as mock_save,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
         ):
-            mock_get.return_value = {"Conditions": []}
+            mock_get.return_value = {
+                "Conditions": [
+                    {
+                        "Field": "http-request-method",
+                        "HttpRequestMethodConfig": {
+                            "Values": ["GET", "POST"],
+                        },
+                    },
+                ]
+            }
             mock_remove.return_value = True
+            mock_now.return_value = now
 
             handle_site_down()
 
             mock_remove.assert_called_once()
             mock_email.assert_called_once()
-            assert state.rule_modified is True
+            mock_save.assert_called_once()
+            assert state.phase == MonitorPhase.ACTIVATED
+            assert state.activated_at == now
+            assert state.original_http_methods == ["GET", "POST"]
 
-    def test_does_not_modify_rule_if_already_modified(self):
-        """Test that rule is not modified twice."""
+    def test_captures_original_http_methods_from_rule(self):
+        """Test that original HTTP methods are extracted from the rule."""
+        state.consecutive_failures = monitor_website.SITE_DOWN_THRESHOLD - 1
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "get_listener_rule_details"
+            ) as mock_get,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "remove_http_method_restriction"
+            ) as mock_remove,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website.send_email"
+            ),
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "save_state_to_s3"
+            ),
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+        ):
+            mock_get.return_value = {
+                "Conditions": [
+                    {
+                        "Field": "http-request-method",
+                        "HttpRequestMethodConfig": {
+                            "Values": ["GET"],
+                        },
+                    },
+                ]
+            }
+            mock_remove.return_value = True
+            mock_now.return_value = datetime(
+                2026, 3, 30, 12, 0, 0, tzinfo=UTC
+            )
+
+            handle_site_down()
+
+            assert state.original_http_methods == ["GET"]
+
+    def test_does_not_modify_rule_if_already_activated(self):
+        """Test that rule is not modified when already activated."""
         state.consecutive_failures = monitor_website.SITE_DOWN_THRESHOLD
-        state.rule_modified = True
+        state.phase = MonitorPhase.ACTIVATED
 
         with mock.patch(
             "knowledge_commons_profiles.cron.monitor_website."
@@ -622,4 +732,703 @@ class TestHandleSiteDown:
             handle_site_down()
 
             mock_email.assert_not_called()
-            assert state.rule_modified is False
+            assert state.phase == MonitorPhase.MONITORING
+
+
+class TestNow:
+    """Tests for the _now helper function."""
+
+    def test_returns_utc_datetime(self):
+        """Test that _now returns a timezone-aware UTC datetime."""
+        result = _now()
+        assert result.tzinfo == UTC
+
+
+class TestSaveStateToS3:
+    """Tests for the save_state_to_s3 function."""
+
+    def test_saves_correct_json_via_aws_cli(self):
+        """Test that correct JSON is piped to aws s3 cp."""
+        now = datetime(2026, 3, 30, 14, 22, 0, tzinfo=UTC)
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(returncode=0)
+
+            result = save_state_to_s3(
+                TEST_S3_BUCKET,
+                TEST_S3_KEY,
+                now,
+                ["GET", "POST"],
+                TEST_RULE_ARN,
+            )
+
+            assert result is True
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args
+            # Verify the JSON input contains correct data
+            input_json = json.loads(call_args.kwargs.get("input", ""))
+            assert input_json["activated_at"] == now.isoformat()
+            assert input_json["original_http_methods"] == ["GET", "POST"]
+            assert input_json["rule_arn"] == TEST_RULE_ARN
+            assert input_json["version"] == 1
+
+    def test_returns_false_on_subprocess_error(self):
+        """Test that False is returned on subprocess error."""
+        now = datetime(2026, 3, 30, 14, 22, 0, tzinfo=UTC)
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "aws", stderr="Error"
+            )
+
+            result = save_state_to_s3(
+                TEST_S3_BUCKET,
+                TEST_S3_KEY,
+                now,
+                ["GET", "POST"],
+                TEST_RULE_ARN,
+            )
+
+            assert result is False
+
+    def test_returns_false_when_no_bucket_configured(self):
+        """Test that False is returned when bucket is empty."""
+        now = datetime(2026, 3, 30, 14, 22, 0, tzinfo=UTC)
+        result = save_state_to_s3(
+            "", TEST_S3_KEY, now, ["GET", "POST"], TEST_RULE_ARN
+        )
+        assert result is False
+
+
+class TestLoadStateFromS3:
+    """Tests for the load_state_from_s3 function."""
+
+    def test_loads_and_parses_json(self):
+        """Test successful load and parse of state JSON."""
+        state_data = {
+            "activated_at": "2026-03-30T14:22:00+00:00",
+            "original_http_methods": ["GET", "POST"],
+            "rule_arn": TEST_RULE_ARN,
+            "version": 1,
+        }
+        with mock.patch("subprocess.run") as mock_run:
+            mock_result = mock.Mock()
+            mock_result.returncode = 0
+            mock_result.stdout = json.dumps(state_data)
+            mock_run.return_value = mock_result
+
+            result = load_state_from_s3(TEST_S3_BUCKET, TEST_S3_KEY)
+
+            assert result == state_data
+
+    def test_returns_none_when_object_not_found(self):
+        """Test that None is returned when S3 object does not exist."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_result = mock.Mock()
+            mock_result.returncode = 1
+            mock_result.stderr = "An error occurred (NoSuchKey)"
+            mock_run.return_value = mock_result
+
+            result = load_state_from_s3(TEST_S3_BUCKET, TEST_S3_KEY)
+
+            assert result is None
+
+    def test_returns_none_on_json_decode_error(self):
+        """Test that None is returned when JSON is invalid."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_result = mock.Mock()
+            mock_result.returncode = 0
+            mock_result.stdout = "not valid json"
+            mock_run.return_value = mock_result
+
+            result = load_state_from_s3(TEST_S3_BUCKET, TEST_S3_KEY)
+
+            assert result is None
+
+    def test_returns_none_on_subprocess_error(self):
+        """Test that None is returned on subprocess error."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "aws", stderr="Error"
+            )
+
+            result = load_state_from_s3(TEST_S3_BUCKET, TEST_S3_KEY)
+
+            assert result is None
+
+    def test_returns_none_when_no_bucket_configured(self):
+        """Test that None is returned when bucket is empty."""
+        result = load_state_from_s3("", TEST_S3_KEY)
+        assert result is None
+
+
+class TestDeleteStateFromS3:
+    """Tests for the delete_state_from_s3 function."""
+
+    def test_deletes_object_via_aws_cli(self):
+        """Test that correct aws s3 rm command is used."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(returncode=0)
+
+            result = delete_state_from_s3(TEST_S3_BUCKET, TEST_S3_KEY)
+
+            assert result is True
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert "s3" in cmd
+            assert "rm" in cmd
+            assert f"s3://{TEST_S3_BUCKET}/{TEST_S3_KEY}" in cmd
+
+    def test_returns_false_on_error(self):
+        """Test that False is returned on subprocess error."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "aws", stderr="Error"
+            )
+
+            result = delete_state_from_s3(TEST_S3_BUCKET, TEST_S3_KEY)
+
+            assert result is False
+
+    def test_returns_false_when_no_bucket(self):
+        """Test that False is returned when bucket is empty."""
+        result = delete_state_from_s3("", TEST_S3_KEY)
+        assert result is False
+
+
+class TestRestoreHttpMethodRestriction:
+    """Tests for the restore_http_method_restriction function."""
+
+    def test_restores_methods_successfully(self):
+        """Test successful restoration of HTTP method restriction."""
+        mock_rule = {
+            "Conditions": [
+                {"Field": "path-pattern", "Values": ["/*"]},
+            ]
+        }
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "get_listener_rule_details"
+            ) as mock_get,
+            mock.patch("subprocess.run") as mock_run,
+        ):
+            mock_get.return_value = mock_rule
+            mock_result = mock.Mock()
+            mock_result.stdout = "{}"
+            mock_run.return_value = mock_result
+
+            result = restore_http_method_restriction(
+                TEST_RULE_ARN, ["GET", "POST"]
+            )
+
+            assert result is True
+            # Verify the conditions include the HTTP method
+            call_args = mock_run.call_args[0][0]
+            conditions_json = call_args[call_args.index("--conditions") + 1]
+            conditions = json.loads(conditions_json)
+            http_method_conds = [
+                c
+                for c in conditions
+                if c.get("Field") == "http-request-method"
+            ]
+            assert len(http_method_conds) == 1
+            assert http_method_conds[0]["HttpRequestMethodConfig"][
+                "Values"
+            ] == ["GET", "POST"]
+
+    def test_returns_false_when_rule_not_found(self):
+        """Test that False is returned when rule cannot be retrieved."""
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website."
+            "get_listener_rule_details"
+        ) as mock_get:
+            mock_get.return_value = None
+
+            result = restore_http_method_restriction(
+                TEST_RULE_ARN, ["GET", "POST"]
+            )
+
+            assert result is False
+
+    def test_idempotent_when_already_present(self):
+        """Test that True is returned if HTTP method already present."""
+        mock_rule = {
+            "Conditions": [
+                {
+                    "Field": "http-request-method",
+                    "HttpRequestMethodConfig": {"Values": ["GET", "POST"]},
+                },
+            ]
+        }
+
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website."
+            "get_listener_rule_details"
+        ) as mock_get:
+            mock_get.return_value = mock_rule
+
+            result = restore_http_method_restriction(
+                TEST_RULE_ARN, ["GET", "POST"]
+            )
+
+            assert result is True
+
+    def test_returns_false_on_subprocess_error(self):
+        """Test that False is returned when AWS CLI command fails."""
+        mock_rule = {
+            "Conditions": [
+                {"Field": "path-pattern", "Values": ["/*"]},
+            ]
+        }
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "get_listener_rule_details"
+            ) as mock_get,
+            mock.patch("subprocess.run") as mock_run,
+        ):
+            mock_get.return_value = mock_rule
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "aws", stderr="Error"
+            )
+
+            result = restore_http_method_restriction(
+                TEST_RULE_ARN, ["GET", "POST"]
+            )
+
+            assert result is False
+
+
+class TestCheckActivationTimeout:
+    """Tests for the check_activation_timeout function."""
+
+    @pytest.fixture(autouse=True)
+    def reset_state(self):
+        """Reset the global state before each test."""
+        state.consecutive_failures = 0
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
+        state.test_mode = False
+        yield
+        state.consecutive_failures = 0
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
+        state.test_mode = False
+
+    def test_deactivates_after_timeout(self):
+        """Test that rule is restored after activation duration."""
+        activated = datetime(2026, 3, 30, 12, 0, 0, tzinfo=UTC)
+        state.phase = MonitorPhase.ACTIVATED
+        state.activated_at = activated
+        state.original_http_methods = ["GET", "POST"]
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "restore_http_method_restriction"
+            ) as mock_restore,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "delete_state_from_s3"
+            ) as mock_delete,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "send_deactivation_email"
+            ) as mock_email,
+        ):
+            # 1 hour + 1 second later
+            mock_now.return_value = datetime(
+                2026, 3, 30, 13, 0, 1, tzinfo=UTC
+            )
+            mock_restore.return_value = True
+
+            check_activation_timeout()
+
+            mock_restore.assert_called_once_with(
+                monitor_website.LISTENER_RULE_ARN, ["GET", "POST"]
+            )
+            mock_delete.assert_called_once()
+            mock_email.assert_called_once()
+            assert state.phase == MonitorPhase.GRACE_PERIOD
+            assert state.grace_period_start is not None
+            assert state.activated_at is None
+            assert state.original_http_methods is None
+            assert state.consecutive_failures == 0
+
+    def test_no_action_before_timeout(self):
+        """Test that nothing happens before timeout expires."""
+        activated = datetime(2026, 3, 30, 12, 0, 0, tzinfo=UTC)
+        state.phase = MonitorPhase.ACTIVATED
+        state.activated_at = activated
+        state.original_http_methods = ["GET", "POST"]
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "restore_http_method_restriction"
+            ) as mock_restore,
+        ):
+            # Only 30 minutes later
+            mock_now.return_value = datetime(
+                2026, 3, 30, 12, 30, 0, tzinfo=UTC
+            )
+
+            check_activation_timeout()
+
+            mock_restore.assert_not_called()
+            assert state.phase == MonitorPhase.ACTIVATED
+
+    def test_handles_restore_failure(self):
+        """Test that state remains ACTIVATED on restore failure."""
+        state.phase = MonitorPhase.ACTIVATED
+        state.activated_at = datetime(
+            2026, 3, 30, 12, 0, 0, tzinfo=UTC
+        )
+        state.original_http_methods = ["GET", "POST"]
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "restore_http_method_restriction"
+            ) as mock_restore,
+        ):
+            mock_now.return_value = datetime(
+                2026, 3, 30, 13, 0, 1, tzinfo=UTC
+            )
+            mock_restore.return_value = False
+
+            check_activation_timeout()
+
+            assert state.phase == MonitorPhase.ACTIVATED
+
+    def test_no_action_when_not_activated(self):
+        """Test that nothing happens when not in ACTIVATED phase."""
+        state.phase = MonitorPhase.MONITORING
+
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website."
+            "restore_http_method_restriction"
+        ) as mock_restore:
+            check_activation_timeout()
+
+            mock_restore.assert_not_called()
+
+
+class TestCheckGracePeriod:
+    """Tests for the check_grace_period function."""
+
+    @pytest.fixture(autouse=True)
+    def reset_state(self):
+        """Reset the global state before each test."""
+        state.consecutive_failures = 0
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
+        state.test_mode = False
+        yield
+        state.consecutive_failures = 0
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
+        state.test_mode = False
+
+    def test_transitions_to_monitoring_after_grace(self):
+        """Test transition to MONITORING after grace period elapsed."""
+        state.phase = MonitorPhase.GRACE_PERIOD
+        state.grace_period_start = datetime(
+            2026, 3, 30, 13, 0, 0, tzinfo=UTC
+        )
+
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website._now"
+        ) as mock_now:
+            # 5 min + 1 second later
+            mock_now.return_value = datetime(
+                2026, 3, 30, 13, 5, 1, tzinfo=UTC
+            )
+
+            check_grace_period()
+
+            assert state.phase == MonitorPhase.MONITORING
+            assert state.grace_period_start is None
+            assert state.consecutive_failures == 0
+
+    def test_no_action_during_grace(self):
+        """Test that nothing happens during grace period."""
+        state.phase = MonitorPhase.GRACE_PERIOD
+        state.grace_period_start = datetime(
+            2026, 3, 30, 13, 0, 0, tzinfo=UTC
+        )
+
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website._now"
+        ) as mock_now:
+            # Only 2 minutes later
+            mock_now.return_value = datetime(
+                2026, 3, 30, 13, 2, 0, tzinfo=UTC
+            )
+
+            check_grace_period()
+
+            assert state.phase == MonitorPhase.GRACE_PERIOD
+
+    def test_no_action_when_not_in_grace(self):
+        """Test that nothing happens when not in GRACE_PERIOD phase."""
+        state.phase = MonitorPhase.MONITORING
+
+        check_grace_period()
+
+        assert state.phase == MonitorPhase.MONITORING
+
+
+class TestInitializeStateFromS3:
+    """Tests for the initialize_state_from_s3 function."""
+
+    @pytest.fixture(autouse=True)
+    def reset_state(self):
+        """Reset the global state before each test."""
+        state.consecutive_failures = 0
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
+        state.test_mode = False
+        yield
+        state.consecutive_failures = 0
+        state.phase = MonitorPhase.MONITORING
+        state.activated_at = None
+        state.original_http_methods = None
+        state.grace_period_start = None
+        state.test_mode = False
+
+    @mock.patch(
+        "knowledge_commons_profiles.cron.monitor_website.S3_STATE_BUCKET",
+        TEST_S3_BUCKET,
+    )
+    def test_restores_active_state(self):
+        """Test that active S3 state is restored on startup."""
+        activated = datetime(2026, 3, 30, 12, 0, 0, tzinfo=UTC)
+        saved_state = {
+            "activated_at": activated.isoformat(),
+            "original_http_methods": ["GET", "POST"],
+            "rule_arn": monitor_website.LISTENER_RULE_ARN,
+            "version": 1,
+        }
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "load_state_from_s3"
+            ) as mock_load,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+        ):
+            mock_load.return_value = saved_state
+            # 30 minutes later - still within window
+            mock_now.return_value = datetime(
+                2026, 3, 30, 12, 30, 0, tzinfo=UTC
+            )
+
+            initialize_state_from_s3()
+
+            assert state.phase == MonitorPhase.ACTIVATED
+            assert state.activated_at == activated
+            assert state.original_http_methods == ["GET", "POST"]
+
+    @mock.patch(
+        "knowledge_commons_profiles.cron.monitor_website.S3_STATE_BUCKET",
+        TEST_S3_BUCKET,
+    )
+    def test_restores_and_deactivates_expired_state(self):
+        """Test that expired S3 state triggers immediate rule restoration."""
+        activated = datetime(2026, 3, 30, 10, 0, 0, tzinfo=UTC)
+        saved_state = {
+            "activated_at": activated.isoformat(),
+            "original_http_methods": ["GET", "POST"],
+            "rule_arn": monitor_website.LISTENER_RULE_ARN,
+            "version": 1,
+        }
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "load_state_from_s3"
+            ) as mock_load,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "restore_http_method_restriction"
+            ) as mock_restore,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "delete_state_from_s3"
+            ) as mock_delete,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "send_deactivation_email"
+            ) as mock_email,
+        ):
+            mock_load.return_value = saved_state
+            # 3 hours later - well past window
+            mock_now.return_value = datetime(
+                2026, 3, 30, 13, 0, 0, tzinfo=UTC
+            )
+            mock_restore.return_value = True
+
+            initialize_state_from_s3()
+
+            mock_restore.assert_called_once_with(
+                monitor_website.LISTENER_RULE_ARN, ["GET", "POST"]
+            )
+            mock_delete.assert_called_once()
+            mock_email.assert_called_once()
+            assert state.phase == MonitorPhase.GRACE_PERIOD
+            assert state.grace_period_start is not None
+
+    @mock.patch(
+        "knowledge_commons_profiles.cron.monitor_website.S3_STATE_BUCKET",
+        TEST_S3_BUCKET,
+    )
+    def test_no_action_when_no_s3_state(self):
+        """Test that nothing happens when no S3 state exists."""
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website."
+            "load_state_from_s3"
+        ) as mock_load:
+            mock_load.return_value = None
+
+            initialize_state_from_s3()
+
+            assert state.phase == MonitorPhase.MONITORING
+
+    @mock.patch(
+        "knowledge_commons_profiles.cron.monitor_website.S3_STATE_BUCKET",
+        "",
+    )
+    def test_no_action_when_no_bucket_configured(self):
+        """Test that nothing happens when no S3 bucket is configured."""
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website."
+            "load_state_from_s3"
+        ) as mock_load:
+            initialize_state_from_s3()
+
+            mock_load.assert_not_called()
+            assert state.phase == MonitorPhase.MONITORING
+
+    @mock.patch(
+        "knowledge_commons_profiles.cron.monitor_website.S3_STATE_BUCKET",
+        TEST_S3_BUCKET,
+    )
+    def test_ignores_mismatched_rule_arn(self):
+        """Test that S3 state with mismatched rule_arn is ignored."""
+        saved_state = {
+            "activated_at": "2026-03-30T12:00:00+00:00",
+            "original_http_methods": ["GET", "POST"],
+            "rule_arn": "arn:aws:wrong-arn",
+            "version": 1,
+        }
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "load_state_from_s3"
+            ) as mock_load,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+        ):
+            mock_load.return_value = saved_state
+            mock_now.return_value = datetime(
+                2026, 3, 30, 12, 30, 0, tzinfo=UTC
+            )
+
+            initialize_state_from_s3()
+
+            assert state.phase == MonitorPhase.MONITORING
+
+    @mock.patch(
+        "knowledge_commons_profiles.cron.monitor_website.S3_STATE_BUCKET",
+        TEST_S3_BUCKET,
+    )
+    def test_handles_restore_failure_on_expired(self):
+        """Test that failed restore on expired state sets ACTIVATED."""
+        activated = datetime(2026, 3, 30, 10, 0, 0, tzinfo=UTC)
+        saved_state = {
+            "activated_at": activated.isoformat(),
+            "original_http_methods": ["GET", "POST"],
+            "rule_arn": monitor_website.LISTENER_RULE_ARN,
+            "version": 1,
+        }
+
+        with (
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "load_state_from_s3"
+            ) as mock_load,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website._now"
+            ) as mock_now,
+            mock.patch(
+                "knowledge_commons_profiles.cron.monitor_website."
+                "restore_http_method_restriction"
+            ) as mock_restore,
+        ):
+            mock_load.return_value = saved_state
+            mock_now.return_value = datetime(
+                2026, 3, 30, 13, 0, 0, tzinfo=UTC
+            )
+            mock_restore.return_value = False
+
+            initialize_state_from_s3()
+
+            assert state.phase == MonitorPhase.ACTIVATED
+            assert state.activated_at == activated
+            assert state.original_http_methods == ["GET", "POST"]
+
+
+class TestSendDeactivationEmail:
+    """Tests for the send_deactivation_email function."""
+
+    def test_sends_with_correct_parameters(self):
+        """Test that deactivation email sends correct content."""
+        with mock.patch(
+            "knowledge_commons_profiles.cron.monitor_website."
+            "SparkPostEmailClient"
+        ) as mock_client_class:
+            mock_client = mock.Mock()
+            mock_client.send_email.return_value = {"success": True}
+            mock_client_class.return_value = mock_client
+
+            result = send_deactivation_email()
+
+            mock_client.send_email.assert_called_once()
+            call_kwargs = mock_client.send_email.call_args[1]
+
+            assert call_kwargs["from_email"] == "system@hcommons.org"
+            expected_subject = (
+                "DDOS Protection has been automatically deactivated"
+            )
+            assert call_kwargs["subject"] == expected_subject
+            assert "restored" in call_kwargs["html_content"].lower()
+            assert call_kwargs["tags"] == ["system", "ddos"]
+            assert result == {"success": True}


### PR DESCRIPTION
Replace the in-memory-only rule_modified flag with a three-phase state machine (MONITORING -> ACTIVATED -> GRACE_PERIOD -> MONITORING) that persists activation state to S3. This allows the monitor to:

- Automatically restore the ALB rule after 1 hour
- Survive ECS container restarts without losing state
- Wait a 5-minute grace period before resuming monitoring
- Send email notifications on both activation and deactivation

Closes #466