### PR TITLE
Improve Welcome and Registration page wording and layout

### DIFF
--- a/knowledge_commons_profiles/static/css/profile.css
+++ b/knowledge_commons_profiles/static/css/profile.css
@@ -1074,12 +1074,12 @@ div {
             transition: all 0.3s ease;
         }
 
-        ol li:hover {
+        .ol-associate li:hover {
             transform: translateY(-2px);
             box-shadow: 0 8px 25px rgba(9, 25, 23, 0.15);
         }
 
-        ol li::before {
+        .ol-associate li::before {
             content: counter(step-counter);
             position: absolute;
             left: -15px;
@@ -1094,6 +1094,33 @@ div {
             justify-content: center;
             font-weight: bold;
             font-size: 0.9rem;
+        }
+
+        .associate-steps {
+            margin-bottom: 35px;
+        }
+
+        .associate-step {
+            margin-bottom: 20px;
+            padding: 20px;
+            background: #f8f9fa;
+            border-radius: 12px;
+            border-left: 4px solid #18453B;
+            position: relative;
+            line-height: 1.6;
+            color: #18453B;
+            transition: all 0.3s ease;
+        }
+
+        .associate-step:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 25px rgba(9, 25, 23, 0.15);
+        }
+
+        .p-associate {
+            margin-top: 20px;
+            color: #18453B;
+            line-height: 1.6;
         }
 
         .a-associate {

--- a/knowledge_commons_profiles/templates/cilogon/association.html
+++ b/knowledge_commons_profiles/templates/cilogon/association.html
@@ -7,27 +7,22 @@
   <div class="container" id="main_container">
     <div class="row">
       <div class="col-12">
-        <h1 class="h1-associate">Welcome to Knowledge Commons...</h1>
-        <h3 class="h3-associate">We need to finish setting up your account for the first time.</h3>
+        <h1 class="h1-associate">Welcome to Knowledge Commons</h1>
+        <h3 class="h3-associate">We need to finish setting up your account.</h3>
         <div>
-          <ol class="ol-associate">
-            <li>If you already have an account, please enter your existing commons email below; if you don't, you can create one now. You will only need to do this once.</li>
-            <div>
-              <form class="form-associate" action="{% url 'associate' %}" method="post">
-                {% csrf_token %}
-                <input type="email" name="email" id="email" placeholder="you@email.com" required />
-                <input type="submit" value="Associate >>" />
-              </form>
+          <div class="associate-steps">
+            <div class="associate-step">
+              If you already have a Knowledge Commons account, please enter your existing account email below. If you are new to the Commons, enter the email address you'd like associated with your account below.
+              <div>
+                <form class="form-associate" action="{% url 'associate' %}" method="post">
+                  {% csrf_token %}
+                  <input type="email" name="email" id="email" placeholder="you@email.com" required />
+                  <input type="submit" value="Submit" />
+                </form>
+              </div>
             </div>
-            <li>If you don't already have an account, please sign up now! You will only need to do this once.</li>
-            <div>
-              <form class="form-associate" action="{% url 'associate' %}" method="post">
-                {% csrf_token %}
-                <input type="submit" value="Sign Up >>" />
-              </form>
-            </div>
-            <li>For any other problems, please email <a class="a-associate" href="mailto:hello@hcommons.org">hello@hcommons.org</a>, if you need help. Please make sure to include this identifier: {{ cilogon_sub }}</li>
-          </ol>
+          </div>
+          <p class="p-associate">For any other problems, please email <a class="a-associate" href="mailto:hello@hcommons.org">hello@hcommons.org</a>, if you need help. Please make sure to include this identifier: {{ cilogon_sub }}</p>
         </div>
 
       </div>

--- a/knowledge_commons_profiles/templates/cilogon/confirm.html
+++ b/knowledge_commons_profiles/templates/cilogon/confirm.html
@@ -7,7 +7,7 @@
   <div class="container" id="main_container">
     <div class="row">
       <div class="col-12">
-        <h1 class="h1-associate">Welcome to Knowledge Commons...</h1>
+        <h1 class="h1-associate">Welcome to Knowledge Commons</h1>
         <h3 class="h3-associate">Thank you for linking your account.</h3>
         <div>
           <p class="p-associate">Please check your email for a confirmation link.</p>

--- a/knowledge_commons_profiles/templates/cilogon/new_user.html
+++ b/knowledge_commons_profiles/templates/cilogon/new_user.html
@@ -26,7 +26,7 @@
           </div>
         {% endif %}
 
-        <h1 class="h1-associate">Welcome to Knowledge Commons...</h1>
+        <h1 class="h1-associate">Welcome to Knowledge Commons</h1>
         <h3 class="h3-associate">Please complete your registration by providing the following information.</h3>
         <div>
           <form class="form-associate" action="{% url 'user_registration' %}" method="post">
@@ -34,6 +34,7 @@
             <ol class="ol-associate">
               <li>
                 Enter your desired username below. This will be used to identify your account.
+                Username must be 3–30 characters and can contain letters, numbers, underscores, and hyphens.
                 <div>
                   <input type="text" name="username" id="username" value="{{ username }}" placeholder="your_username" required />
                 </div>
@@ -74,12 +75,12 @@
                   </label>
                 </div>
               </li>
-              <li>
-                <input type="submit" value="Register" />
-              </li>
-              <li>For any problems, please email <a class="a-associate" href="mailto:hello@hcommons.org">hello@hcommons.org</a> if you need help.</li>
             </ol>
+            <div class="associate-step">
+              <input type="submit" value="Register" />
+            </div>
           </form>
+          <p class="p-associate">For any problems, please email <a class="a-associate" href="mailto:hello@hcommons.org">hello@hcommons.org</a> if you need help.</p>
           <div class="modal fade" id="termsModal" tabindex="-1" aria-labelledby="termsModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-lg modal-dialog-scrollable">
               <div class="modal-content">


### PR DESCRIPTION
## Summary
- Removes ellipsis from headings on Welcome, Registration, and Confirm pages
- Updates Welcome page wording for clarity, changes button from "Associate >>" to "Submit", removes redundant "Sign Up" section and numbered step hierarchy
- Adds username constraint hints on Registration page, moves submit button and help text outside the numbered list
- Adds `.associate-steps`/`.associate-step` CSS classes for non-numbered containers, scopes `ol li` hover/counter styles to `.ol-associate`

Closes #359