### PR TITLE
Fix CI deploy job name showing template garbage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: docker compose -f docker-compose.github.yml down
 
   deploy:
-    name: Deploy (${{ github.ref_name == 'main' && 'production' || 'dev' }})
+    name: Deploy
     runs-on: ubuntu-24.04-arm
     needs: [linter, test]
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Reverts the deploy job `name` field from a dynamic expression back to plain "Deploy"
- The ternary expression `${{ github.ref_name == 'main' && 'production' || 'dev' }}` renders as literal template text in the GitHub checks UI on pull requests where the job is skipped

Closes #483