### PR TITLE
fix(settings): read WORKS_UPDATE_ENDPOINTS from env

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -496,9 +496,9 @@ KNOWN_SOCIETY_MAPPINGS = {"stemedplus": "STEMED+"}
 
 LOGOUT_ENDPOINTS = env.list("LOGOUT_ENDPOINTS", default=[])
 
-WORKS_UPDATE_ENDPOINTS = [
-    "https://localhost/" if DEBUG else "https://works.hcommons.org/"
-]
+WORKS_UPDATE_ENDPOINTS = env.list(
+    "WORKS_UPDATE_ENDPOINTS", default=["https://works.hcommons.org/"]
+)
 
 WEBHOOK_TOKEN = env("WEBHOOK_TOKEN")
 WEBHOOK_URLS = env.list("WEBHOOK_URLS", default=[])


### PR DESCRIPTION
## Summary
- Replaces hardcoded `WORKS_UPDATE_ENDPOINTS` (which used `DEBUG` to toggle between `localhost` and `works.hcommons.org`) with `env.list()` reading from an environment variable
- Defaults to `["https://works.hcommons.org/"]` when unset
- Dev environments can set `WORKS_UPDATE_ENDPOINTS=https://localhost/` in `.env`

Resolves #503