### PR TITLE
fix(api): scope cover image query to current user

### DIFF
--- a/knowledge_commons_profiles/newprofile/api.py
+++ b/knowledge_commons_profiles/newprofile/api.py
@@ -746,7 +746,12 @@ class API:
         if cover:
             return cover.file_path
 
-        result = WpUserMeta.objects.filter(meta_key="_bb_cover_photo").first()
+        result = WpUserMeta.objects.filter(
+            meta_key="_bb_cover_photo", user=self.wp_user
+        ).first()
+
+        if not result:
+            return None
 
         return phpserialize.unserialize(result.meta_value.encode())[
             b"attachment"

--- a/knowledge_commons_profiles/newprofile/tests/test_api.py
+++ b/knowledge_commons_profiles/newprofile/tests/test_api.py
@@ -1351,6 +1351,16 @@ class GetCoverImageTests(django.test.TestCase):
         self.mock_coverimage_set = mock.MagicMock()
         self.profile_obj.coverimage_set = self.mock_coverimage_set
 
+        # Mock wp_user property
+        self.wp_user_patcher = mock.patch.object(
+            self.model_instance.__class__,
+            "wp_user",
+            new_callable=mock.PropertyMock,
+        )
+        self.mock_wp_user_prop = self.wp_user_patcher.start()
+        self.mock_wp_user = mock.MagicMock()
+        self.mock_wp_user_prop.return_value = self.mock_wp_user
+
         # Mock WpUserMeta.objects.filter
         self.filter_patcher = mock.patch(
             "knowledge_commons_profiles.newprofile.api.WpUserMeta.objects."
@@ -1371,6 +1381,7 @@ class GetCoverImageTests(django.test.TestCase):
     def tearDown(self):
         """Clean up after the tests."""
         self.profile_patcher.stop()
+        self.wp_user_patcher.stop()
         self.filter_patcher.stop()
         self.phpserialize_patcher.stop()
 
@@ -1408,6 +1419,11 @@ class GetCoverImageTests(django.test.TestCase):
         # Assert the result is the WordPress image path
         self.assertEqual(result, wp_image_path)
 
+        # Assert the filter was called with user scope
+        self.mock_filter.assert_called_once_with(
+            meta_key="_bb_cover_photo", user=self.mock_wp_user
+        )
+
     def test_get_cover_image_no_local_or_wordpress_image(self):
         """Test when no cover image is found in either location."""
         # Set up mock to return no local cover image
@@ -1416,10 +1432,9 @@ class GetCoverImageTests(django.test.TestCase):
         # Set up mock to return no WordPress metadata
         self.mock_queryset.first.return_value = None
 
-        # Call the method and expect AttributeError (trying to access
-        # meta_value on None)
-        with self.assertRaises(AttributeError):
-            self.model_instance.get_cover_image()
+        # Should return None, not raise an error
+        result = self.model_instance.get_cover_image()
+        self.assertIsNone(result)
 
     def test_get_cover_image_with_invalid_serialized_data(self):
         """Test handling of invalid PHP serialized data."""


### PR DESCRIPTION
## Summary
- The `get_cover_image()` WordPress fallback queried `wp_usermeta` for `meta_key='_bb_cover_photo'` without filtering by user, causing a full table scan (slow DB query flagged in Sentry as KCPROFILES-DEV-1C) and potentially returning another user's cover photo
- Added `user=self.wp_user` filter to scope the query correctly
- Added null check so the method returns `None` instead of crashing when no WordPress cover photo exists

## Test plan
- [x] Updated existing test to assert user-scoped filter is called
- [x] Updated no-image test to expect `None` return instead of `AttributeError`
- [x] All 811 tests pass