### PR TITLE
fix(mastodon): downgrade HTTP errors to warning level logging

### DIFF
--- a/knowledge_commons_profiles/newprofile/mastodon.py
+++ b/knowledge_commons_profiles/newprofile/mastodon.py
@@ -169,6 +169,9 @@ class MastodonFeed:
         try:
             response = requests.get(self.api_url, timeout=self.timeout)
             response.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            logger.warning("HTTP error fetching %s: %s", self.api_url, exc)
+            return []
         except requests.exceptions.RequestException:
             logger.exception("Error fetching %s", self.api_url)
             return []

--- a/knowledge_commons_profiles/newprofile/tests/test_mastodon.py
+++ b/knowledge_commons_profiles/newprofile/tests/test_mastodon.py
@@ -148,6 +148,59 @@ xmlns:media="http://search.yahoo.com/mrss/">
         result = self.mastodon_feed.latest_posts()
 
         self.assertEqual(result, [])
+        self.mock_logger.exception.assert_called()
+
+    def test_fetch_http_error_uses_warning(self):
+        """Test that HTTP errors (410, 404) use warning, not exception."""
+        response = mock.MagicMock()
+        response.status_code = 410
+        http_error = requests.exceptions.HTTPError(
+            "410 Client Error: Gone", response=response
+        )
+        self.mock_response.raise_for_status.side_effect = http_error
+
+        result = self.mastodon_feed.latest_posts()
+
+        self.assertEqual(result, [])
+        self.mock_logger.warning.assert_called()
+        self.mock_logger.exception.assert_not_called()
+
+    def test_fetch_404_uses_warning(self):
+        """Test that 404 errors use warning, not exception."""
+        response = mock.MagicMock()
+        response.status_code = 404
+        http_error = requests.exceptions.HTTPError(
+            "404 Client Error: Not Found", response=response
+        )
+        self.mock_response.raise_for_status.side_effect = http_error
+
+        result = self.mastodon_feed.latest_posts()
+
+        self.assertEqual(result, [])
+        self.mock_logger.warning.assert_called()
+        self.mock_logger.exception.assert_not_called()
+
+    def test_fetch_connection_error_uses_exception(self):
+        """Test that connection errors still use logger.exception."""
+        self.mock_requests_get.side_effect = (
+            requests.exceptions.ConnectionError("Connection refused")
+        )
+
+        result = self.mastodon_feed.latest_posts()
+
+        self.assertEqual(result, [])
+        self.mock_logger.exception.assert_called()
+
+    def test_fetch_timeout_uses_exception(self):
+        """Test that timeout errors still use logger.exception."""
+        self.mock_requests_get.side_effect = (
+            requests.exceptions.Timeout("Request timed out")
+        )
+
+        result = self.mastodon_feed.latest_posts()
+
+        self.assertEqual(result, [])
+        self.mock_logger.exception.assert_called()
 
     def test_fetch_xml_parsing_error(self):
         """Test error handling when XML parsing fails."""


### PR DESCRIPTION
## Summary
- Mastodon RSS feed HTTP errors (410 Gone, 404 Not Found) from deleted accounts were being logged with `logger.exception`, sending tracebacks to Sentry as errors
- Catch `HTTPError` separately and log at warning level — these are expected conditions, not bugs
- Connection failures and timeouts still use `logger.exception` for proper Sentry alerting

Closes #507

## Test plan
- [x] New tests verify 410 and 404 use `logger.warning` not `logger.exception`
- [x] New tests verify connection errors and timeouts still use `logger.exception`
- [x] Existing test updated to assert `logger.exception` is called for generic request failures
- [x] All 815 tests pass