### PR TITLE
fix(rest_api): tolerate scheme-less WORKS_UPDATE_ENDPOINTS entries

### DIFF
--- a/knowledge_commons_profiles/rest_api/idms_api.py
+++ b/knowledge_commons_profiles/rest_api/idms_api.py
@@ -205,6 +205,13 @@ class APIClientConfig(BaseModel):
     backoff_factor: float = Field(0.3, ge=0)
     status_forcelist: list[int] | None = None
 
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _ensure_scheme(cls, value):
+        if isinstance(value, str) and "://" not in value:
+            return f"https://{value}"
+        return value
+
     class Config:
         validate_assignment = True
 

--- a/knowledge_commons_profiles/rest_api/tests/test_idms_api.py
+++ b/knowledge_commons_profiles/rest_api/tests/test_idms_api.py
@@ -1,0 +1,41 @@
+import unittest
+
+from pydantic import ValidationError
+
+from knowledge_commons_profiles.rest_api.idms_api import APIClientConfig
+
+
+class TestAPIClientConfigBaseURLScheme(unittest.TestCase):
+    """Verify APIClientConfig normalises scheme-less base URLs.
+
+    Regression: GitHub issue #529. A deployment env var
+    (WORKS_UPDATE_ENDPOINTS) without an http(s):// scheme crashed the
+    /activate/ view because pydantic's HttpUrl rejected the raw host.
+    """
+
+    def test_base_url_without_scheme_gets_https_prepended(self):
+        config = APIClientConfig(base_url="works.hcommons-staging.org/")
+        self.assertTrue(
+            str(config.base_url).startswith("https://"),
+            msg=f"expected https:// prefix, got {config.base_url!s}",
+        )
+        self.assertIn("works.hcommons-staging.org", str(config.base_url))
+
+    def test_base_url_with_https_scheme_preserved(self):
+        config = APIClientConfig(base_url="https://works.hcommons.org/")
+        self.assertTrue(str(config.base_url).startswith("https://"))
+
+    def test_base_url_with_http_scheme_preserved(self):
+        config = APIClientConfig(base_url="http://localhost:8000/")
+        url_str = str(config.base_url)
+        self.assertTrue(url_str.startswith("http://"))
+        self.assertFalse(url_str.startswith("https://"))
+
+    def test_base_url_bare_host_no_trailing_slash(self):
+        config = APIClientConfig(base_url="works.hcommons-staging.org")
+        self.assertTrue(str(config.base_url).startswith("https://"))
+        self.assertIn("works.hcommons-staging.org", str(config.base_url))
+
+    def test_base_url_still_rejects_garbage(self):
+        with self.assertRaises(ValidationError):
+            APIClientConfig(base_url="not a url at all")


### PR DESCRIPTION
## Summary
- Users clicking the activation email link crash with a pydantic `ValidationError` because `APIClientConfig.base_url` (typed as `HttpUrl`) rejects the staging `WORKS_UPDATE_ENDPOINTS` value `works.hcommons-staging.org/`, which has no scheme.
- Added a `field_validator(mode="before")` on `APIClientConfig.base_url` that prepends `https://` when the input string has no scheme. Runs before `HttpUrl` parsing, so the three call sites (`send_association_message`, `send_webhook_updates`, `hit_works_endpoints`) are all implicitly protected.
- Added 5 unit tests covering scheme-less hosts, preserved `http://`/`https://`, bare hostname, and still-rejected garbage input.

The deployment env var should still be corrected to include `https://` for explicitness, but the code now tolerates either form.

Closes #529

## Test plan
- [x] `PYTHONUNBUFFERED=1 DJANGO_SETTINGS_MODULE=config.settings.test DJANGO_READ_DOT_ENV_FILE=True uv run --group local ./manage.py test knowledge_commons_profiles.rest_api.tests.test_idms_api` passes (5/5).
- [x] Full test suite green in CI.
- [x] Manual: activation link on the dev/staging deployment completes without 500 once the branch is deployed there.