### PR TITLE
fix(cilogon): defend email verification against link-scanner pre-fetch (#542)

### DIFF
--- a/knowledge_commons_profiles/cilogon/tests/test_edge_cases.py
+++ b/knowledge_commons_profiles/cilogon/tests/test_edge_cases.py
@@ -318,13 +318,36 @@ class TestNewEmailVerifiedUnauthenticated(TestCase):
         middleware.process_request(request)
         request.session.save()
 
-    def test_new_email_verified_works_when_authenticated(self):
-        """new_email_verified should work correctly when user is logged in"""
+    def test_new_email_verified_post_appends_and_redirects(self):
+        """POST should append the email and redirect to manage_login."""
         from knowledge_commons_profiles.cilogon.models import EmailVerification
         from knowledge_commons_profiles.cilogon.views import new_email_verified
 
-        # Create verification
-        _ = EmailVerification.objects.create(
+        EmailVerification.objects.create(
+            sub="newemail@example.com",
+            secret_uuid="test-uuid-123",
+            profile=self.profile,
+        )
+
+        request = self.factory.post("/new-email-verified/test-uuid-123/")
+        request.user = self.user
+        self._add_session(request)
+
+        response = new_email_verified(request, "test-uuid-123")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("testuser", response.url)
+
+        self.profile.refresh_from_db()
+        self.assertIn("newemail@example.com", self.profile.emails)
+
+    def test_new_email_verified_get_renders_confirm_does_not_append(self):
+        """GET should render the confirm page and not modify the profile
+        or consume the token (defends against link-scanner pre-fetch)."""
+        from knowledge_commons_profiles.cilogon.models import EmailVerification
+        from knowledge_commons_profiles.cilogon.views import new_email_verified
+
+        verification = EmailVerification.objects.create(
             sub="newemail@example.com",
             secret_uuid="test-uuid-123",
             profile=self.profile,
@@ -336,13 +359,31 @@ class TestNewEmailVerifiedUnauthenticated(TestCase):
 
         response = new_email_verified(request, "test-uuid-123")
 
-        # Should redirect to manage_login with correct username
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("testuser", response.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"<form", response.content)
 
-        # Email should be added to profile
         self.profile.refresh_from_db()
-        self.assertIn("newemail@example.com", self.profile.emails)
+        self.assertNotIn("newemail@example.com", self.profile.emails)
+        self.assertTrue(
+            EmailVerification.objects.filter(id=verification.id).exists()
+        )
+
+    def test_new_email_verified_invalid_token_renders_invalid_page(self):
+        """An unknown secret renders the invalid-link page (410) on both
+        GET and POST rather than 404ing."""
+        from knowledge_commons_profiles.cilogon.views import new_email_verified
+
+        get_request = self.factory.get("/new-email-verified/no-such/")
+        get_request.user = self.user
+        self._add_session(get_request)
+        get_response = new_email_verified(get_request, "no-such")
+        self.assertEqual(get_response.status_code, 410)
+
+        post_request = self.factory.post("/new-email-verified/no-such/")
+        post_request.user = self.user
+        self._add_session(post_request)
+        post_response = new_email_verified(post_request, "no-such")
+        self.assertEqual(post_response.status_code, 410)
 
 
 class TestMakeEmailPrimaryWordpressSync(TestCase):

--- a/knowledge_commons_profiles/cilogon/tests/test_views_extended.py
+++ b/knowledge_commons_profiles/cilogon/tests/test_views_extended.py
@@ -14,7 +14,6 @@ from django.contrib.sessions.backends.db import SessionStore
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.db import DatabaseError
 from django.db import IntegrityError
-from django.http import Http404
 from django.test import RequestFactory
 from django.test import override_settings
 from django.urls import reverse
@@ -947,17 +946,36 @@ class AssociationTests(CILogonTestBase):
 
 
 class EmailVerificationTests(CILogonTestBase):
-    """Test cases for email verification functionality"""
+    """Test cases for email verification functionality.
+
+    The view splits handling: GET/HEAD render an interstitial confirmation
+    page that does NOT consume the token (defends against link-scanner
+    pre-fetch); POST consumes the token and runs side effects. Missing or
+    expired tokens render a friendly invalid-link page (HTTP 410 Gone).
+    """
 
     def setUp(self):
+        super().setUp()
         self.factory = RequestFactory()
         self.profile = Profile.objects.create(
             username="testuser", email="test@example.com", name="Test User"
         )
+        self.user = User.objects.create_user("testuser", password="pw")
 
-    def test_activate_valid_verification(self):
-        """Test activation with valid verification"""
-        request = self.factory.get("/")
+    def _add_session_and_messages(self, request):
+        middleware = SessionMiddleware(get_response=MagicMock())
+        middleware.process_request(request)
+        request.session.save()
+        request._messages = FallbackStorage(request)
+
+    # ---------- POST: happy paths ----------
+
+    def test_activate_post_consumes_and_logs_in(self):
+        """POST consumes the token, creates SubAssociation, logs the user in."""
+        request = self.factory.post("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
         verification = EmailVerification.objects.create(
             secret_uuid="test-uuid",
             profile=self.profile,
@@ -965,48 +983,225 @@ class EmailVerificationTests(CILogonTestBase):
             idp_name="Test University",
         )
 
-        with patch(
-            "knowledge_commons_profiles.cilogon.views.send_association_message"
+        with (
+            patch(
+                "knowledge_commons_profiles.cilogon.views.send_association_message"
+            ),
+            patch(
+                "knowledge_commons_profiles.cilogon.views.hcommons_add_new_user_to_mailchimp"
+            ),
+            patch(
+                "knowledge_commons_profiles.cilogon.views.ExternalSync.sync"
+            ),
         ):
-            activate(request, verification.secret_uuid)
+            response = activate(request, verification.secret_uuid)
 
-        # Should redirect to my_profile (302, not 200)
-        # self.assertEqual(response.status_code, 302)
-        # self.assertEqual(response.url, reverse("my_profile"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("my_profile"))
 
-        # Should create SubAssociation with idp_name propagated
         sub_assoc = SubAssociation.objects.get(
             sub="cilogon_sub_123", profile=self.profile
         )
         self.assertEqual(sub_assoc.idp_name, "Test University")
 
-        # Should delete EmailVerification
         self.assertFalse(
             EmailVerification.objects.filter(id=verification.id).exists()
         )
 
-    def test_activate_invalid_secret_uuid(self):
-        """Test activation with invalid secret UUID"""
-        request = self.factory.get("/")
+    # ---------- GET / HEAD: scanner-safe ----------
 
-        with self.assertRaises(Http404):
-            activate(request, "invalid-uuid")
-
-    def test_activate_wrong_secret(self):
-        """Test activation with wrong secret key (different from existing)"""
+    def test_activate_get_renders_confirm_does_not_consume(self):
+        """GET renders the confirm page and does not touch the token or run
+        any side effects."""
         request = self.factory.get("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
+        verification = EmailVerification.objects.create(
+            secret_uuid="test-uuid",
+            profile=self.profile,
+            sub="cilogon_sub_123",
+            idp_name="Test University",
+        )
+
+        with (
+            patch(
+                "knowledge_commons_profiles.cilogon.views.send_association_message"
+            ) as mock_assoc,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.hcommons_add_new_user_to_mailchimp"
+            ) as mock_mc,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.ExternalSync.sync"
+            ) as mock_sync,
+        ):
+            response = activate(request, verification.secret_uuid)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"<form", response.content)
+        # Token still exists
+        self.assertTrue(
+            EmailVerification.objects.filter(id=verification.id).exists()
+        )
+        # No SubAssociation created
+        self.assertFalse(
+            SubAssociation.objects.filter(
+                sub="cilogon_sub_123", profile=self.profile
+            ).exists()
+        )
+        # No side effects
+        mock_assoc.assert_not_called()
+        mock_mc.assert_not_called()
+        mock_sync.assert_not_called()
+
+    def test_activate_head_does_not_consume(self):
+        """HEAD does not consume the token or run side effects."""
+        request = self.factory.generic("HEAD", "/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
+        verification = EmailVerification.objects.create(
+            secret_uuid="test-uuid",
+            profile=self.profile,
+            sub="cilogon_sub_123",
+        )
+
+        with (
+            patch(
+                "knowledge_commons_profiles.cilogon.views.send_association_message"
+            ) as mock_assoc,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.hcommons_add_new_user_to_mailchimp"
+            ) as mock_mc,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.ExternalSync.sync"
+            ) as mock_sync,
+        ):
+            activate(request, verification.secret_uuid)
+
+        self.assertTrue(
+            EmailVerification.objects.filter(id=verification.id).exists()
+        )
+        self.assertFalse(
+            SubAssociation.objects.filter(
+                sub="cilogon_sub_123", profile=self.profile
+            ).exists()
+        )
+        mock_assoc.assert_not_called()
+        mock_mc.assert_not_called()
+        mock_sync.assert_not_called()
+
+    # ---------- Missing / expired token ----------
+
+    def test_activate_get_missing_token_renders_invalid(self):
+        """GET with an unknown token renders the invalid-link page (410)."""
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
+        response = activate(request, "no-such-uuid")
+
+        self.assertEqual(response.status_code, 410)
+        self.assertIn(b"no longer valid", response.content.lower())
+
+    def test_activate_post_missing_token_renders_invalid(self):
+        """POST with an unknown token renders the invalid-link page (410)."""
+        request = self.factory.post("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
+        response = activate(request, "no-such-uuid")
+
+        self.assertEqual(response.status_code, 410)
+        self.assertIn(b"no longer valid", response.content.lower())
+
+    def test_activate_post_wrong_secret_renders_invalid(self):
+        """POST with a different valid-shaped secret renders the invalid
+        page (410) rather than 404."""
+        request = self.factory.post("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
         EmailVerification.objects.create(
             secret_uuid="test-uuid",
             profile=self.profile,
             sub="cilogon_sub_123",
         )
 
-        with self.assertRaises(Http404):
-            activate(request, "wrong-secret")
+        response = activate(request, "wrong-secret")
 
-    def test_activate_database_error(self):
-        """Test activation with database error"""
-        request = self.factory.get("/")
+        self.assertEqual(response.status_code, 410)
+
+    def test_activate_repeated_post_renders_invalid(self):
+        """A second POST with the same secret (already consumed) renders
+        the invalid page rather than 500ing."""
+        verification = EmailVerification.objects.create(
+            secret_uuid="test-uuid",
+            profile=self.profile,
+            sub="cilogon_sub_123",
+        )
+
+        request1 = self.factory.post("/")
+        request1.user = AnonymousUser()
+        self._add_session_and_messages(request1)
+
+        with (
+            patch(
+                "knowledge_commons_profiles.cilogon.views.send_association_message"
+            ),
+            patch(
+                "knowledge_commons_profiles.cilogon.views.hcommons_add_new_user_to_mailchimp"
+            ),
+            patch(
+                "knowledge_commons_profiles.cilogon.views.ExternalSync.sync"
+            ),
+        ):
+            response1 = activate(request1, verification.secret_uuid)
+        self.assertEqual(response1.status_code, 302)
+
+        request2 = self.factory.post("/")
+        request2.user = AnonymousUser()
+        self._add_session_and_messages(request2)
+        response2 = activate(request2, verification.secret_uuid)
+
+        self.assertEqual(response2.status_code, 410)
+
+    def test_activate_expired_verification_renders_invalid(self):
+        """Expired verification renders 410 invalid page on either verb;
+        the row is NOT deleted by the view (GC handles cleanup separately)."""
+        request = self.factory.post("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
+        verification = EmailVerification.objects.create(
+            secret_uuid="test-uuid",
+            profile=self.profile,
+            sub="cilogon_sub_123",
+        )
+
+        with patch.object(
+            EmailVerification, "is_expired", return_value=True
+        ):
+            response = activate(request, verification.secret_uuid)
+
+        self.assertEqual(response.status_code, 410)
+        self.assertTrue(
+            EmailVerification.objects.filter(id=verification.id).exists()
+        )
+        self.assertFalse(
+            SubAssociation.objects.filter(
+                sub="cilogon_sub_123", profile=self.profile
+            ).exists()
+        )
+
+    # ---------- DB error during POST is still propagated ----------
+
+    def test_activate_post_database_error_propagates(self):
+        """A DB error inside the POST consumption flow is not swallowed."""
+        request = self.factory.post("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
         verification = EmailVerification.objects.create(
             secret_uuid="test-uuid",
             profile=self.profile,
@@ -1022,45 +1217,63 @@ class EmailVerificationTests(CILogonTestBase):
         ):
             activate(request, verification.secret_uuid)
 
-    def test_activate_expired_verification(self):
-        """Test activation with expired verification redirects with error"""
-        from django.contrib.messages.storage.fallback import FallbackStorage
-        from django.contrib.sessions.backends.db import SessionStore
+    # ---------- Regression: do not call garbage_collect ----------
 
-        request = self.factory.get("/")
-        request.session = SessionStore()
-        request.session.create()
-        request._messages = FallbackStorage(request)
-
+    def test_activate_does_not_call_garbage_collect(self):
+        """The view must not invoke EmailVerification.garbage_collect itself
+        — it would write on every scanner pre-fetch."""
         verification = EmailVerification.objects.create(
             secret_uuid="test-uuid",
             profile=self.profile,
             sub="cilogon_sub_123",
         )
 
-        # Mock garbage_collect to prevent it from deleting the verification
-        # and mock is_expired to return True
+        # GET path
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+        with patch.object(EmailVerification, "garbage_collect") as mock_gc:
+            activate(request, verification.secret_uuid)
+        mock_gc.assert_not_called()
+
+        # POST path
+        request2 = self.factory.post("/")
+        request2.user = AnonymousUser()
+        self._add_session_and_messages(request2)
         with (
-            patch.object(EmailVerification, "garbage_collect"),
-            patch.object(EmailVerification, "is_expired", return_value=True),
+            patch.object(EmailVerification, "garbage_collect") as mock_gc2,
+            patch(
+                "knowledge_commons_profiles.cilogon.views.send_association_message"
+            ),
+            patch(
+                "knowledge_commons_profiles.cilogon.views.hcommons_add_new_user_to_mailchimp"
+            ),
+            patch(
+                "knowledge_commons_profiles.cilogon.views.ExternalSync.sync"
+            ),
         ):
-            response = activate(request, verification.secret_uuid)
+            activate(request2, verification.secret_uuid)
+        mock_gc2.assert_not_called()
 
-        # Should redirect to login
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("login"))
+    # ---------- CSRF ----------
 
-        # Verification should be deleted (by the activate view)
-        self.assertFalse(
-            EmailVerification.objects.filter(id=verification.id).exists()
+    def test_activate_confirm_page_renders_csrf_token_input(self):
+        """The confirm page must include a CSRF token input so the POST
+        survives Django's CSRF middleware."""
+        EmailVerification.objects.create(
+            secret_uuid="csrf-uuid",
+            profile=self.profile,
+            sub="cilogon_sub_999",
         )
 
-        # SubAssociation should NOT be created
-        self.assertFalse(
-            SubAssociation.objects.filter(
-                sub="cilogon_sub_123", profile=self.profile
-            ).exists()
-        )
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        self._add_session_and_messages(request)
+
+        response = activate(request, "csrf-uuid")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"csrfmiddlewaretoken", response.content)
 
     def test_confirm_view(self):
         """Test confirmation view"""

--- a/knowledge_commons_profiles/cilogon/views.py
+++ b/knowledge_commons_profiles/cilogon/views.py
@@ -738,30 +738,48 @@ def _add_secondary_email(profile: Profile | None, request):
 
 
 @login_required
+@require_http_methods(["GET", "HEAD", "POST"])
 def new_email_verified(request, secret_key):
     """
-    The activation view clicked by a user from email
+    Add a secondary email after the user clicks the verification link.
+
+    GET / HEAD render an interstitial confirmation page that does NOT
+    consume the token; POST consumes the token and appends the email.
+    This split defends against email link-safety scanners (Mimecast,
+    ProofPoint URL Defender, MS Defender SafeLinks, etc.) that pre-fetch
+    URLs with GET before the human ever clicks.
     """
 
-    EmailVerification.garbage_collect()
+    try:
+        verify: EmailVerification = EmailVerification.objects.get(
+            secret_uuid=secret_key
+        )
+    except EmailVerification.DoesNotExist:
+        return render(
+            request,
+            "cilogon/verification_invalid.html",
+            {"flow": "new_email"},
+            status=410,
+        )
 
-    # get the verification by secret key or 404
-    verify: EmailVerification = get_object_or_404(
-        EmailVerification, secret_uuid=secret_key
-    )
+    if request.method in ("GET", "HEAD"):
+        return render(
+            request,
+            "cilogon/verification_confirm.html",
+            {
+                "flow": "new_email",
+                "action_url": reverse("new_email", args=[secret_key]),
+            },
+        )
 
-    # add the email
+    # POST: consume token and append email
     if verify.sub not in verify.profile.emails:
         verify.profile.emails.append(verify.sub)
         verify.profile.emails = sorted(verify.profile.emails)
         verify.profile.save()
 
-    # delete the verification as it's no longer needed
     verify.delete()
 
-    # TODO: send a webhook sync request
-
-    # redirect the user to their Profile page
     return redirect(reverse("manage_login", args=[request.user.username]))
 
 
@@ -1284,32 +1302,54 @@ def confirm(request):
     return render(request, "cilogon/confirm.html", {})
 
 
+@require_http_methods(["GET", "HEAD", "POST"])
 def activate(request, secret_key: str):
     """
     The activation view clicked by a user from email.
 
-    This handles both:
+    Handles two flows:
     1. New user registration verification (first SubAssociation for profile)
     2. Existing user adding a new login method (additional SubAssociation)
+
+    GET / HEAD render an interstitial confirmation page that does NOT
+    consume the token; POST consumes the token and runs side effects.
+    The split defends against email link-safety scanners (Mimecast,
+    ProofPoint URL Defender, MS Defender SafeLinks, etc.) that pre-fetch
+    URLs with GET before the human ever clicks. Missing or expired
+    tokens render a friendly invalid-link page (HTTP 410 Gone).
     """
 
-    EmailVerification.garbage_collect()
-
-    # get the verification by secret key or 404
-    verify: EmailVerification = get_object_or_404(
-        EmailVerification, secret_uuid=secret_key
-    )
-
-    # check that this hasn't expired
-    if verify.is_expired():
-        verify.delete()
-        messages.error(
-            request,
-            "This verification link has expired. Please request a new one.",
+    try:
+        verify: EmailVerification = EmailVerification.objects.get(
+            secret_uuid=secret_key
         )
-        return redirect(reverse("login"))
+    except EmailVerification.DoesNotExist:
+        return render(
+            request,
+            "cilogon/verification_invalid.html",
+            {"flow": "activate"},
+            status=410,
+        )
 
-    # Save references before deleting the verification
+    if verify.is_expired():
+        return render(
+            request,
+            "cilogon/verification_invalid.html",
+            {"flow": "activate", "expired": True},
+            status=410,
+        )
+
+    if request.method in ("GET", "HEAD"):
+        return render(
+            request,
+            "cilogon/verification_confirm.html",
+            {
+                "flow": "activate",
+                "action_url": reverse("activate", args=[secret_key]),
+            },
+        )
+
+    # POST: consume the token and run side effects
     profile = verify.profile
     sub = verify.sub
     idp_name = verify.idp_name

--- a/knowledge_commons_profiles/static/css/profile.css
+++ b/knowledge_commons_profiles/static/css/profile.css
@@ -1176,7 +1176,7 @@ div {
             text-transform: uppercase;
             letter-spacing: 0.5px;
             margin-bottom: 20px;
-            width: 200px;
+            min-width: 400px;
         }
 
         .form-associate input[type="submit"]:hover {

--- a/knowledge_commons_profiles/templates/cilogon/verification_confirm.html
+++ b/knowledge_commons_profiles/templates/cilogon/verification_confirm.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}
+  Confirm Your Email
+{% endblock title %}
+{% block content %}
+  <div class="container" id="main_container">
+    <div class="row">
+      <div class="col-12">
+        <h1 class="h1-associate">Confirm Your Email</h1>
+        <h3 class="h3-associate">
+          {% if flow == "new_email" %}
+            One more step to add this email address to your Knowledge Commons account.
+          {% else %}
+            One more step to activate your Knowledge Commons account.
+          {% endif %}
+        </h3>
+        <div>
+          <div class="associate-steps">
+            <div class="associate-step">
+              For your security, please click the button below to confirm that
+              you opened this link yourself.
+              <div>
+                <form class="form-associate" action="{{ action_url }}" method="post">
+                  {% csrf_token %}
+                  <input type="submit" value="Confirm my email" />
+                </form>
+              </div>
+            </div>
+          </div>
+          <p class="p-associate">If you have any trouble, please email <a class="a-associate" href="mailto:hello@hcommons.org">hello@hcommons.org</a>.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/knowledge_commons_profiles/templates/cilogon/verification_invalid.html
+++ b/knowledge_commons_profiles/templates/cilogon/verification_invalid.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}
+  Verification Link Unavailable
+{% endblock title %}
+{% block content %}
+  <div class="container" id="main_container">
+    <div class="row">
+      <div class="col-12">
+        <h1 class="h1-associate">This Link Is No Longer Valid</h1>
+        <h3 class="h3-associate">
+          {% if expired %}
+            Your verification link has expired.
+          {% else %}
+            This verification link is no longer valid — it may already have been used.
+          {% endif %}
+        </h3>
+        <div>
+          <div class="associate-steps">
+            <div class="associate-step">
+              Verification links are single-use and expire after a short time.
+              {% if flow == "new_email" %}
+                Please <a class="a-associate" href="{% url 'login' %}">sign in</a> and try adding the email again from your account settings.
+              {% else %}
+                Please <a class="a-associate" href="{% url 'login' %}">sign in again</a> to request a new verification link.
+              {% endif %}
+            </div>
+          </div>
+          <p class="p-associate">If you continue to have trouble, please email <a class="a-associate" href="mailto:hello@hcommons.org">hello@hcommons.org</a>.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/knowledge_commons_profiles/templates/mail/add_new_email.html
+++ b/knowledge_commons_profiles/templates/mail/add_new_email.html
@@ -118,6 +118,12 @@
             border-radius: 0 8px 8px 0;
         }
 
+        /* Confirm-on-next-page note */
+        .confirm-note {
+            font-size: 14px;
+            color: #666666;
+        }
+
         /* Footer styles */
         .footer {
             background-color: #18453b;
@@ -211,6 +217,8 @@
         <div class="highlight-box">
             <strong>To add "{{ email }}" to your Knowledge Commons account:</strong> Please <a href="{{ request.scheme }}://{{ request.get_host }}{% url "new_email" uuid %}">verify and associate this address</a>.
         </div>
+
+        <p class="confirm-note">For your security, you will be asked to confirm on the next page before this address is added.</p>
 
         <p>Thank you for being part of our growing community. Together, we're building something remarkable.</p>
 

--- a/knowledge_commons_profiles/templates/mail/associate.html
+++ b/knowledge_commons_profiles/templates/mail/associate.html
@@ -118,6 +118,12 @@
             border-radius: 0 8px 8px 0;
         }
 
+        /* Confirm-on-next-page note */
+        .confirm-note {
+            font-size: 14px;
+            color: #666666;
+        }
+
         /* Footer styles */
         .footer {
             background-color: #18453b;
@@ -211,6 +217,8 @@
         <div class="highlight-box">
             <strong>To allow access to your Knowledge Commons account with the new login method:</strong> Please <a href="https://{{ request.get_host }}{% url "activate" uuid %}">verify and associate your account</a>.
         </div>
+
+        <p class="confirm-note">For your security, you will be asked to confirm on the next page before the new login method is associated.</p>
 
         <p>Thank you for being part of our growing community. Together, we're building something remarkable.</p>
 

--- a/knowledge_commons_profiles/templates/mail/verify_registration.html
+++ b/knowledge_commons_profiles/templates/mail/verify_registration.html
@@ -118,6 +118,12 @@
             border-radius: 0 8px 8px 0;
         }
 
+        /* Confirm-on-next-page note */
+        .confirm-note {
+            font-size: 14px;
+            color: #666666;
+        }
+
         /* Footer styles */
         .footer {
             background-color: #18453b;
@@ -211,6 +217,8 @@
         <div class="highlight-box">
             <strong>To verify your email and activate your account:</strong> Please <a href="https://{{ request.get_host }}{% url "activate" uuid %}">click here to verify your email</a>.
         </div>
+
+        <p class="confirm-note">For your security, you will be asked to confirm on the next page before your account is activated.</p>
 
         <p>If you did not create an account with Knowledge Commons, you can safely ignore this email.</p>
 


### PR DESCRIPTION
## Summary

- Splits `activate` and `new_email_verified` so GET/HEAD render an interstitial confirmation page that does not consume the verification token, and POST consumes it. This neutralises Mimecast / ProofPoint URL Defender / Microsoft Defender SafeLinks / Gmail-style URL pre-fetch, which was the root cause of users seeing `Http404 "No EmailVerification matches the given query"` when clicking the link in their inbox.
- Replaces the bare 404 with a friendly invalid-link page (HTTP 410 Gone) for missing or expired tokens, matching the existing `h1-associate` / `associate-step` site aesthetic.
- Drops the per-request `EmailVerification.garbage_collect()` call, which (a) made the `is_expired()` branch partly unreachable and (b) would have caused a write on every scanner GET under the new model.
- Widens the `.form-associate` submit button (`min-width: 400px`) so the longer "Confirm my email" label fits without truncation; existing Submit/Register buttons display unchanged at the new floor.
- The three verification email templates pick up a small "you'll be asked to confirm on the next page" note.

Closes #542.

## Test plan

- [x] Full Django suite (`./manage.py test`) — 897/897 green.
- [x] `EmailVerificationTests` rewritten + 7 new tests covering GET-doesn't-consume, HEAD-doesn't-consume, POST happy-path, missing-token (GET and POST) → 410, repeated POST → 410, expired → 410 (row preserved), no `garbage_collect` regression guard, CSRF input present.
- [x] `new_email_verified` tests rewritten to POST; new tests for GET-doesn't-append and invalid-token GET/POST → 410.
- [x] Manual scanner-prefetch simulation against a local runserver: two `curl -X GET` and one `curl -X HEAD` against the activate URL leave the token in the DB and create no `SubAssociation`. Form POST consumes as expected.
- [x] Visual check of both new pages and the widened button.
- [x] Reviewer: confirm copy on the new pages and the email "confirm on next page" note reads well.